### PR TITLE
Inject logger into VC SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ case .failure(let error):
 ```
 
 At the time of publish, we support the following requirements on a request:
-| Requirement                  	| Description 	| Supported on Type of Request 	|
+| Requirement                  	| Description 	| Supported on Request 	|
 |------------------------------	|-------------	|------------------------------	|
 | GroupRequirement             	| A verifier/issuer could request multiple requirements. If more than one requirement is requested, a GroupRequirement contains a list of the requirements.        	| Issuance/Presentation        	|
 | VerifiedIdRequirement        	| A verifier/issuer can request a VerifiedId. See below for helper methods to fulfill the requirement.       	| Issuance/Presentation        	|

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ let verifiedId = verifiedIdClient.decode(from: encodedVerifiedId)
 5. Switch Target to WalletLibraryDemo.
 6. Run the Sample App on a simulator.
 
-
 ## Documentation
 
 * [External Architecture](Docs/LibraryArchitecture.md)
@@ -148,4 +147,3 @@ Any use of third-party trademarks or logos are subject to those third-party's po
 [badge-license]: https://img.shields.io/cocoapods/l/WalletLibrary
 [badge-azure-pipline]: https://decentralized-identity.visualstudio.com/Core/_apis/build/status/iOS%20Wallet%20Library
 [badge-privatepreview]: https://img.shields.io/badge/status-Private%20Preview-red.svg
-

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ case .failure(let error):
 At the time of publish, we support the following requirements on a request:
 | Requirement                  	| Description 	| Supported on Type of Request 	|
 |------------------------------	|-------------	|------------------------------	|
-| GroupRequirement             	| A verifier/issuer could request multiple requirements. A GroupRequirement contains a list of requirements to support this use case.        	| Issuance/Presentation        	|
-| VerifiedIdRequirement        	| A verifier will require one or more Verified Ids to complete a presentation flow. An issuer can also request Verified Ids.        	| Issuance/Presentation        	|
+| GroupRequirement             	| A verifier/issuer could request multiple requirements. If more than one requirement is requested, a GroupRequirement contains a list of the requirements.        	| Issuance/Presentation        	|
+| VerifiedIdRequirement        	| A verifier/issuer can request a VerifiedId. See below for helper methods to fulfill the requirement.       	| Issuance/Presentation        	|
 | SelfAttestedClaimRequirement 	| An issuer might require a self-attested claim that is simply a string value.        	| Issuance                     	|
 | PinRequirement               	| An issuer might require a pin from user.         	| Issuance                     	|
 | AccessTokenRequirement       	| An issuer might request an Access Token. An Access Token must be retrieved using an external library.        	| Issuance                     	|

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # Microsoft Entra Wallet Library
+![badge-privatepreview]
+![badge-packagemanagers-supported] 
+![badge-pod-version] 
+![badge-languages] 
+![badge-platforms]
+![badge-license]
+![badge-azure-pipline]
 
 ## Introduction
 The Microsoft Entra Wallet Library for iOS gives your app the ability to begin using the Microsoft Entra Verified Id platform by supporting the issuance and presentation of Verified Ids in accordance with OpenID Connect, Presentation Exchange, Verifiable Credentials, and more up and coming industry standards.
@@ -41,21 +48,21 @@ case .failure(let error):
 }
 ```
 
-At the time of publish, we support the following requirements for an issuance request:
-* GroupRequirement
-* SelfAttestedClaimRequirement
-* IdTokenRequirement
-* AccessTokenRequirement
-* VerifiedIdRequirement
-* PinRequirement
-
-We support the following requirements for a presentation request:
-* VerifiedIdRequirement
+At the time of publish, we support the following requirements on a request:
+| Requirement                  	| Description 	| Supported on Type of Request 	|
+|------------------------------	|-------------	|------------------------------	|
+| GroupRequirement             	| A verifier/issuer could request multiple requirements. A GroupRequirement contains a list of requirements to support this use case.        	| Issuance/Presentation        	|
+| VerifiedIdRequirement        	| A verifier will require one or more Verified Ids to complete a presentation flow. An issuer can also request Verified Ids.        	| Issuance/Presentation        	|
+| SelfAttestedClaimRequirement 	| An issuer might require a self-attested claim that is simply a string value.        	| Issuance                     	|
+| PinRequirement               	| An issuer might require a pin from user.         	| Issuance                     	|
+| AccessTokenRequirement       	| An issuer might request an Access Token. An Access Token must be retrieved using an external library.        	| Issuance                     	|
+| IdTokenRequirement           	| An issuer might request an Id Token. If the Id Token is not already injected into the request, an Id Token must be retrieved using an external library.       	| Issuance                     	|
 
 To fulfill a requirement, cast it to the correct Requirement type and use the `fulfill` method.
 ```Swift
-let verifiedIdRequirement = presentationRequest.requirement as! VerifiedIdRequirement
-verifiedIdRequirement.fulfill(with: <Insert VerifiedId>)
+if let verifiedIdRequirement = presentationRequest.requirement as? VerifiedIdRequirement {
+    verifiedIdRequirement.fulfill(with: <Insert VerifiedId>)
+}
 ```
 
 VerifiedIdRequirement contains a helper function `getMatches` that will filter all of the VerifiedId that satisfies the constraints on the VerifiedIdRequirement from a list of VerifiedIds.
@@ -97,6 +104,16 @@ let encodedVerifiedId = verifiedIdClient.encode(verifiedId: <Insert VerifiedId>)
 let verifiedId = verifiedIdClient.decode(from: encodedVerifiedId)
 ```
 
+## Sample App
+1. Clone the repository.
+2. Open a terminal window and go to the location where you cloned the repository.
+3. Type in: git submodule update --init –recursive
+   a. This step is important as it will initialize the submodules used in the library.
+4. Open the Wallet Library workspace in Xcode. (WalletLibrary.xcworkspace)
+5. Switch Target to WalletLibraryDemo.
+6. Run the Sample App on a simulator.
+
+
 ## Documentation
 
 * [External Architecture](Docs/LibraryArchitecture.md)
@@ -123,3 +140,12 @@ trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
+
+[badge-pod-version]: https://img.shields.io/cocoapods/v/WalletLibrary
+[badge-packagemanagers-supported]: https://img.shields.io/badge/supports-CocoaPods-green.svg
+[badge-languages]: https://img.shields.io/badge/languages-Swift-blue.svg
+[badge-platforms]: https://img.shields.io/badge/platforms-iOS-lightgrey.svg
+[badge-license]: https://img.shields.io/cocoapods/l/WalletLibrary
+[badge-azure-pipline]: https://decentralized-identity.visualstudio.com/Core/_apis/build/status/iOS%20Wallet%20Library
+[badge-privatepreview]: https://img.shields.io/badge/status-Private%20Preview-red.svg
+

--- a/README.md
+++ b/README.md
@@ -145,5 +145,5 @@ Any use of third-party trademarks or logos are subject to those third-party's po
 [badge-languages]: https://img.shields.io/badge/languages-Swift-blue.svg
 [badge-platforms]: https://img.shields.io/badge/platforms-iOS-lightgrey.svg
 [badge-license]: https://img.shields.io/cocoapods/l/WalletLibrary
-[badge-azure-pipline]: https://decentralized-identity.visualstudio.com/Core/_apis/build/status/iOS%20Wallet%20Library
+[badge-azure-pipline]: https://decentralized-identity.visualstudio.com/Core/_apis/build/status/iOS%20Wallet%20Library?branchName=dev
 [badge-privatepreview]: https://img.shields.io/badge/status-Private%20Preview-red.svg

--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		550E3214298B11A5004E7716 /* Requirement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550E3213298B11A5004E7716 /* Requirement.swift */; };
 		550E3217298B1236004E7716 /* RequesterStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550E3216298B1236004E7716 /* RequesterStyle.swift */; };
 		5524A53D29D2370E00C5F18D /* VerifiedIdDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BA2DD829CDFA6100BB8207 /* VerifiedIdDecoderTests.swift */; };
+		5524A59F29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5524A59E29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift */; };
 		552E509B293E6AB200868F47 /* WalletLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 552E5092293E6AB200868F47 /* WalletLibrary.framework */; };
 		552E50A0293E6AB200868F47 /* VerifiedIdClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552E509F293E6AB200868F47 /* VerifiedIdClientTests.swift */; };
 		552E50A1293E6AB200868F47 /* WalletLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = 552E5095293E6AB200868F47 /* WalletLibrary.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -351,6 +352,7 @@
 		550E3211298B1150004E7716 /* VerifiedIdRequestInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerifiedIdRequestInput.swift; sourceTree = "<group>"; };
 		550E3213298B11A5004E7716 /* Requirement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Requirement.swift; sourceTree = "<group>"; };
 		550E3216298B1236004E7716 /* RequesterStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequesterStyle.swift; sourceTree = "<group>"; };
+		5524A59E29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLibraryVCSDKLogConsumer.swift; sourceTree = "<group>"; };
 		552E5092293E6AB200868F47 /* WalletLibrary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WalletLibrary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		552E5095293E6AB200868F47 /* WalletLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WalletLibrary.h; sourceTree = "<group>"; };
 		552E509A293E6AB200868F47 /* WalletLibraryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WalletLibraryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1162,6 +1164,7 @@
 				5534E668294A0C3F005D0765 /* Mapper.swift */,
 				550E320B298B0F30004E7716 /* WalletLibraryLogConsumer.swift */,
 				550E320D298B0FAC004E7716 /* WalletLibraryLogger.swift */,
+				5524A59E29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1565,6 +1568,7 @@
 				55DECBEB29B954F500D5C802 /* PresentationResponseContainer+WalletLibrary.swift in Sources */,
 				559BD3AD299AE6C000BD61AC /* IssuanceRequest+RawManifest.swift in Sources */,
 				559BD3B2299B0A0400BD61AC /* AttestationsDescriptor+Mappable.swift in Sources */,
+				5524A59F29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift in Sources */,
 				5534E64D294A0888005D0765 /* PresentationDescriptor+Mappable.swift in Sources */,
 				55E3370C293FD61E00CD2ED7 /* SelfAttestedClaimRequirement.swift in Sources */,
 				55E3376829437E3500CD2ED7 /* OpenIdForVCResolver.swift in Sources */,

--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		5524A53D29D2370E00C5F18D /* VerifiedIdDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BA2DD829CDFA6100BB8207 /* VerifiedIdDecoderTests.swift */; };
 		5524A59F29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5524A59E29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift */; };
 		5524A5B629D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5524A5B529D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift */; };
+		5524A60C29D634BC00C5F18D /* VerifiedIdLogo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5524A5F629D634BC00C5F18D /* VerifiedIdLogo.swift */; };
+		5524A60E29D635A700C5F18D /* WalletLibraryLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5524A60D29D635A700C5F18D /* WalletLibraryLoggerTests.swift */; };
 		552E509B293E6AB200868F47 /* WalletLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 552E5092293E6AB200868F47 /* WalletLibrary.framework */; };
 		552E50A0293E6AB200868F47 /* VerifiedIdClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552E509F293E6AB200868F47 /* VerifiedIdClientTests.swift */; };
 		552E50A1293E6AB200868F47 /* WalletLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = 552E5095293E6AB200868F47 /* WalletLibrary.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -355,6 +357,8 @@
 		550E3216298B1236004E7716 /* RequesterStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequesterStyle.swift; sourceTree = "<group>"; };
 		5524A59E29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLibraryVCSDKLogConsumer.swift; sourceTree = "<group>"; };
 		5524A5B529D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLibraryVCSDKLogConsumerTests.swift; sourceTree = "<group>"; };
+		5524A5F629D634BC00C5F18D /* VerifiedIdLogo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerifiedIdLogo.swift; sourceTree = "<group>"; };
+		5524A60D29D635A700C5F18D /* WalletLibraryLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLibraryLoggerTests.swift; sourceTree = "<group>"; };
 		552E5092293E6AB200868F47 /* WalletLibrary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WalletLibrary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		552E5095293E6AB200868F47 /* WalletLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WalletLibrary.h; sourceTree = "<group>"; };
 		552E509A293E6AB200868F47 /* WalletLibraryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WalletLibraryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1079,7 +1083,7 @@
 				55E336D5293FA78C00CD2ED7 /* VerifiedIdClaim.swift */,
 				55BA2DCE29CDFA1A00BB8207 /* VerifiedIdDecoder.swift */,
 				55BA2DCF29CDFA1A00BB8207 /* VerifiedIdEncoder.swift */,
-				5524A5BF29D6225500C5F18D /* VerifiedIdLogo.swift */,
+				5524A5F629D634BC00C5F18D /* VerifiedIdLogo.swift */,
 			);
 			path = VerifiedId;
 			sourceTree = "<group>";
@@ -1187,6 +1191,7 @@
 			children = (
 				55E3376A29478C5000CD2ED7 /* AsyncWrapperTests.swift */,
 				5524A5B529D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift */,
+				5524A60D29D635A700C5F18D /* WalletLibraryLoggerTests.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1577,7 +1582,6 @@
 				55E3370C293FD61E00CD2ED7 /* SelfAttestedClaimRequirement.swift in Sources */,
 				55E3376829437E3500CD2ED7 /* OpenIdForVCResolver.swift in Sources */,
 				55A81BE52991B2E5002C259A /* RequestResolverFactory.swift in Sources */,
-				5524A5C029D6225500C5F18D /* VerifiedIdLogo.swift in Sources */,
 				559BD485299D8DCC00BD61AC /* VerifiedIdRequester.swift in Sources */,
 				55EA178D29CA4F120085E29E /* VerifiedIdIssuanceRequest.swift in Sources */,
 				55E2F086299573C30008010D /* OpenIdVerifierStyle.swift in Sources */,
@@ -1600,6 +1604,7 @@
 				55BA2DD329CDFA1A00BB8207 /* EncodedVerifiedId.swift in Sources */,
 				55E2F06C299553300008010D /* PresentationRequest+Mappable.swift in Sources */,
 				559BD4B5299EE10800BD61AC /* IssuanceService+VerifiableCredentialRequester.swift in Sources */,
+				5524A60C29D634BC00C5F18D /* VerifiedIdLogo.swift in Sources */,
 				55A81BCA2991AB82002C259A /* RequestResolving.swift in Sources */,
 				55E2F0882995743D0008010D /* LinkedDomainResult+Mappable.swift in Sources */,
 				55E33708293FD25900CD2ED7 /* AccessTokenRequirement.swift in Sources */,
@@ -1625,6 +1630,7 @@
 				553CC0A029A98003005A5FD6 /* VCVerifiedIdTests.swift in Sources */,
 				55A81C132991C829002C259A /* MockHandler.swift in Sources */,
 				559BD3072995ABD300BD61AC /* PresentationInputDescriptor+MappableTests.swift in Sources */,
+				5524A60E29D635A700C5F18D /* WalletLibraryLoggerTests.swift in Sources */,
 				559BD4EB299EEAC400BD61AC /* GroupRequirementTests.swift in Sources */,
 				55A81C072991BB2C002C259A /* RequestResolverFactoryTests.swift in Sources */,
 				553CC09B29A96ECD005A5FD6 /* MockIssuanceResponseContaining.swift in Sources */,

--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		550E3217298B1236004E7716 /* RequesterStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550E3216298B1236004E7716 /* RequesterStyle.swift */; };
 		5524A53D29D2370E00C5F18D /* VerifiedIdDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BA2DD829CDFA6100BB8207 /* VerifiedIdDecoderTests.swift */; };
 		5524A59F29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5524A59E29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift */; };
+		5524A5B629D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5524A5B529D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift */; };
 		552E509B293E6AB200868F47 /* WalletLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 552E5092293E6AB200868F47 /* WalletLibrary.framework */; };
 		552E50A0293E6AB200868F47 /* VerifiedIdClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552E509F293E6AB200868F47 /* VerifiedIdClientTests.swift */; };
 		552E50A1293E6AB200868F47 /* WalletLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = 552E5095293E6AB200868F47 /* WalletLibrary.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -353,6 +354,7 @@
 		550E3213298B11A5004E7716 /* Requirement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Requirement.swift; sourceTree = "<group>"; };
 		550E3216298B1236004E7716 /* RequesterStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequesterStyle.swift; sourceTree = "<group>"; };
 		5524A59E29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLibraryVCSDKLogConsumer.swift; sourceTree = "<group>"; };
+		5524A5B529D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLibraryVCSDKLogConsumerTests.swift; sourceTree = "<group>"; };
 		552E5092293E6AB200868F47 /* WalletLibrary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WalletLibrary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		552E5095293E6AB200868F47 /* WalletLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WalletLibrary.h; sourceTree = "<group>"; };
 		552E509A293E6AB200868F47 /* WalletLibraryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WalletLibraryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1183,6 +1185,7 @@
 			isa = PBXGroup;
 			children = (
 				55E3376A29478C5000CD2ED7 /* AsyncWrapperTests.swift */,
+				5524A5B529D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1633,6 +1636,7 @@
 				550A91952994025C0014D030 /* OpenIdURLRequestResolverTests.swift in Sources */,
 				55BA2DD629CDFA4600BB8207 /* MockVerifiedIdEncoder.swift in Sources */,
 				559BD3052995AB8F00BD61AC /* PresentationDefinition+MappableTests.swift in Sources */,
+				5524A5B629D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift in Sources */,
 				55BA2DDB29CDFA6100BB8207 /* VerifiedIdEncoderTests.swift in Sources */,
 				55A81C0D2991BF86002C259A /* MockInput.swift in Sources */,
 				55DECBED29BA29FB00D5C802 /* PresentationResponseContainerExtensionTests.swift in Sources */,

--- a/WalletLibrary/WalletLibrary.xcodeproj/xcshareddata/xcschemes/WalletLibrary.xcscheme
+++ b/WalletLibrary/WalletLibrary.xcodeproj/xcshareddata/xcschemes/WalletLibrary.xcscheme
@@ -26,11 +26,21 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "552E5099293E6AB200868F47"
+            BuildableName = "WalletLibraryTests.xctest"
+            BlueprintName = "WalletLibraryTests"
+            ReferencedContainer = "container:WalletLibrary.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "552E5099293E6AB200868F47"

--- a/WalletLibrary/WalletLibrary.xcodeproj/xcshareddata/xcschemes/WalletLibrary.xcscheme
+++ b/WalletLibrary/WalletLibrary.xcodeproj/xcshareddata/xcschemes/WalletLibrary.xcscheme
@@ -32,9 +32,9 @@
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "552E5099293E6AB200868F47"
-            BuildableName = "WalletLibraryTests.xctest"
-            BlueprintName = "WalletLibraryTests"
+            BlueprintIdentifier = "552E5091293E6AB200868F47"
+            BuildableName = "WalletLibrary.framework"
+            BlueprintName = "WalletLibrary"
             ReferencedContainer = "container:WalletLibrary.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>

--- a/WalletLibrary/WalletLibrary/Utilities/WalletLibraryLogger.swift
+++ b/WalletLibrary/WalletLibrary/Utilities/WalletLibraryLogger.swift
@@ -81,11 +81,11 @@ struct WalletLibraryLogger {
             line: line)
     }
     
-    private func log(_ traceLevel: TraceLevel,
-                     message: String,
-                     functionName: String,
-                     file: String,
-                     line: Int) {
+    func log(_ traceLevel: TraceLevel,
+             message: String,
+             functionName: String,
+             file: String,
+             line: Int) {
         consumers.forEach { logger in
             logger.log(traceLevel,
                        message: message,

--- a/WalletLibrary/WalletLibrary/Utilities/WalletLibraryVCSDKLogConsumer.swift
+++ b/WalletLibrary/WalletLibrary/Utilities/WalletLibraryVCSDKLogConsumer.swift
@@ -8,7 +8,7 @@
 #endif
 
 /**
- * Protocol for consumers of the library to use to inject logging into the library.
+ *  A VC Log Consumer that can be injected into the VC SDK and route to Wallet Library Logger.
  */
 struct WalletLibraryVCSDKLogConsumer: VCLogConsumer {
     

--- a/WalletLibrary/WalletLibrary/Utilities/WalletLibraryVCSDKLogConsumer.swift
+++ b/WalletLibrary/WalletLibrary/Utilities/WalletLibraryVCSDKLogConsumer.swift
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+#if canImport(VCEntities)
+    import VCEntities
+#endif
+
+/**
+ * Protocol for consumers of the library to use to inject logging into the library.
+ */
+struct WalletLibraryVCSDKLogConsumer: VCLogConsumer {
+    
+    let logger: WalletLibraryLogger
+    
+    init(logger: WalletLibraryLogger) {
+        self.logger = logger
+    }
+    
+    func log(_ traceLevel: VCTraceLevel, message: String, functionName: String, file: String, line: Int) {
+        logger.log(convertVCTraceLevelToWalletLibraryTraceLevel(traceLevel),
+                   message: message,
+                   functionName: functionName,
+                   file: file,
+                   line: line)
+    }
+    
+    func event(name: String, properties: [String : String]?, measurements: [String : NSNumber]?) {
+        logger.event(name: name, properties: properties, measurements: measurements)
+    }
+    
+    /// TODO: converge VCLogger and Wallet Library Logger.
+    private func convertVCTraceLevelToWalletLibraryTraceLevel(_ traceLevel: VCTraceLevel) -> TraceLevel {
+        switch traceLevel {
+        case .INFO:
+            return .INFO
+        case .VERBOSE:
+            return .VERBOSE
+        case .DEBUG:
+            return .DEBUG
+        case .WARN:
+            return .WARN
+        case .ERROR:
+            return .ERROR
+        case .FAILURE:
+            return .FAILURE
+        }
+    }
+}

--- a/WalletLibrary/WalletLibrary/Utilities/WalletLibraryVCSDKLogConsumer.swift
+++ b/WalletLibrary/WalletLibrary/Utilities/WalletLibraryVCSDKLogConsumer.swift
@@ -12,7 +12,7 @@
  */
 struct WalletLibraryVCSDKLogConsumer: VCLogConsumer {
     
-    let logger: WalletLibraryLogger
+    private let logger: WalletLibraryLogger
     
     init(logger: WalletLibraryLogger) {
         self.logger = logger

--- a/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
@@ -24,8 +24,9 @@ public class VerifiedIdClientBuilder {
 
     /// Builds the VerifiedIdClient with the set configuration from the builder.
     public func build() -> VerifiedIdClient {
-        /// TODO: inject log consumer and access group identifier into vc sdk.
-        let _ = VerifiableCredentialSDK.initialize()
+        /// TODO: access group identifier into vc sdk.
+        let vcLogConsumer = WalletLibraryVCSDKLogConsumer(logger: logger)
+        let _ = VerifiableCredentialSDK.initialize(logConsumer: vcLogConsumer)
         
         let configuration = LibraryConfiguration(logger: logger,
                                                  mapper: Mapper(),

--- a/WalletLibrary/WalletLibraryTests/Mocks/Utilities/MockLogConsumer.swift
+++ b/WalletLibrary/WalletLibraryTests/Mocks/Utilities/MockLogConsumer.swift
@@ -7,13 +7,33 @@
 
 struct MockLogConsumer: WalletLibraryLogConsumer, Equatable {
     
+    let uuid = UUID()
+    
+    let logCallback: ((TraceLevel, String, String, String, Int) -> ())?
+    
+    let eventCallback: ((String) -> ())?
+    
+    init(logCallback: ((TraceLevel, String, String, String, Int) -> ())? = nil,
+         eventCallback: ((String) -> ())? = nil) {
+        self.logCallback = logCallback
+        self.eventCallback = eventCallback
+    }
+    
     func log(_ traceLevel: TraceLevel,
              message: String,
              functionName: String,
              file: String,
-             line: Int) {}
+             line: Int) {
+        logCallback?(traceLevel, message, functionName, file, line)
+    }
     
     func event(name: String,
                properties: [String : String]?,
-               measurements: [String : NSNumber]?) {}
+               measurements: [String : NSNumber]?) {
+        eventCallback?(name)
+    }
+    
+    static func == (lhs: MockLogConsumer, rhs: MockLogConsumer) -> Bool {
+        return lhs.uuid == rhs.uuid
+    }
 }

--- a/WalletLibrary/WalletLibraryTests/Utilities/WalletLibraryLoggerTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Utilities/WalletLibraryLoggerTests.swift
@@ -1,0 +1,120 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import XCTest
+@testable import WalletLibrary
+
+class WalletLibraryLoggerTests: XCTestCase {
+    
+    let mockMessage = "mock debug message"
+    let mockFunctionName = "mock function"
+    let mockFile = "mock file"
+    let mockLine = 63
+    
+    private func testLogConsumer(with traceLevel: TraceLevel) -> ((TraceLevel, String, String, String, Int) -> ())? {
+        func testLogConsumer(traceLevel: TraceLevel, message: String, functionName: String, file: String, line: Int) {
+            // Assert
+            XCTAssertEqual(traceLevel, traceLevel)
+            XCTAssertEqual(message, mockMessage)
+            XCTAssertEqual(functionName, mockFunctionName)
+            XCTAssertEqual(file, mockFile)
+            XCTAssertEqual(line, mockLine)
+        }
+        
+        return testLogConsumer
+    }
+    
+    func testDebug_WithMockConsumer_LogsInMockConsumer() async throws {
+        // Arrange
+        let testLogConsumer = testLogConsumer(with: .DEBUG)
+        let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
+        let logger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        
+        // Act
+        logger.logDebug(message: mockMessage,
+                        functionName: mockFunctionName,
+                        file: mockFile,
+                        line: mockLine)
+    }
+    
+    func testInfo_WithMockConsumer_LogsInMockConsumer() async throws {
+        // Arrange
+        let testLogConsumer = testLogConsumer(with: .INFO)
+        let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
+        let logger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        
+        // Act
+        logger.logInfo(message: mockMessage,
+                       functionName: mockFunctionName,
+                       file: mockFile,
+                       line: mockLine)
+    }
+    
+    func testVerbose_WithMockConsumer_LogsInMockConsumer() async throws {
+        // Arrange
+        let testLogConsumer = testLogConsumer(with: .VERBOSE)
+        let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
+        let logger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        
+        // Act
+        logger.logVerbose(message: mockMessage,
+                          functionName: mockFunctionName,
+                          file: mockFile,
+                          line: mockLine)
+    }
+    
+    func testWarn_WithMockConsumer_LogsInMockConsumer() async throws {
+        // Arrange
+        let testLogConsumer = testLogConsumer(with: .WARN)
+        let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
+        let logger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        
+        // Act
+        logger.logWarning(message: mockMessage,
+                          functionName: mockFunctionName,
+                          file: mockFile,
+                          line: mockLine)
+    }
+    
+    func testFailure_WithMockConsumer_LogsInMockConsumer() async throws {
+        // Arrange
+        let testLogConsumer = testLogConsumer(with: .FAILURE)
+        let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
+        let logger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        
+        // Act
+        logger.logFailure(message: mockMessage,
+                          functionName: mockFunctionName,
+                          file: mockFile,
+                          line: mockLine)
+    }
+    
+    func testError_WithMockConsumer_LogsInMockConsumer() async throws {
+        // Arrange
+        let testLogConsumer = testLogConsumer(with: .ERROR)
+        let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
+        let logger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        
+        // Act
+        logger.logError(message: mockMessage,
+                        functionName: mockFunctionName,
+                        file: mockFile,
+                        line: mockLine)
+    }
+    
+    func testEvent_WitMockConsumer_LogsInMockConsumer() async throws {
+        // Arrange
+        let mockName = "mock message"
+        func eventCalled(name: String) {
+            XCTAssertEqual(name, mockName)
+        }
+        
+        let mockWalletLibraryLogConsumer = MockLogConsumer(eventCallback: eventCalled)
+        let logger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        
+        // Act
+        logger.event(name: mockName)
+    }
+}

--- a/WalletLibrary/WalletLibraryTests/Utilities/WalletLibraryVCSDKLogConsumerTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Utilities/WalletLibraryVCSDKLogConsumerTests.swift
@@ -1,0 +1,136 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import XCTest
+import VCEntities
+@testable import WalletLibrary
+
+class WalletLibraryVCSDKLogConsumerTests: XCTestCase {
+    
+    let mockMessage = "mock debug message"
+    let mockFunctionName = "mock function"
+    let mockFile = "mock file"
+    let mockLine = 63
+    
+    private func testLogConsumer(with traceLevel: TraceLevel) -> ((TraceLevel, String, String, String, Int) -> ())? {
+        func testLogConsumer(traceLevel: TraceLevel, message: String, functionName: String, file: String, line: Int) {
+            // Assert
+            XCTAssertEqual(traceLevel, traceLevel)
+            XCTAssertEqual(message, mockMessage)
+            XCTAssertEqual(functionName, mockFunctionName)
+            XCTAssertEqual(file, mockFile)
+            XCTAssertEqual(line, mockLine)
+        }
+        
+        return testLogConsumer
+    }
+    
+    func testlog_WithDebug_LogsInWalletLibraryLogger() async throws {
+        // Arrange
+        let testLogConsumer = testLogConsumer(with: .DEBUG)
+        let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
+        let walletLibraryLogger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let walletLibraryVCSDKLogConsumer = WalletLibraryVCSDKLogConsumer(logger: walletLibraryLogger)
+        
+        // Act
+        walletLibraryVCSDKLogConsumer.log(.DEBUG,
+                                          message: mockMessage,
+                                          functionName: mockFunctionName,
+                                          file: mockFile,
+                                          line: mockLine)
+    }
+    
+    func testlog_WithInfo_LogsInWalletLibraryLogger() async throws {
+        // Arrange
+        let testLogConsumer = testLogConsumer(with: .INFO)
+        let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
+        let walletLibraryLogger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let walletLibraryVCSDKLogConsumer = WalletLibraryVCSDKLogConsumer(logger: walletLibraryLogger)
+        
+        // Act
+        walletLibraryVCSDKLogConsumer.log(.INFO,
+                                          message: mockMessage,
+                                          functionName: mockFunctionName,
+                                          file: mockFile,
+                                          line: mockLine)
+    }
+    
+    func testlog_WithError_LogsInWalletLibraryLogger() async throws {
+        // Arrange
+        let testLogConsumer = testLogConsumer(with: .ERROR)
+        let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
+        let walletLibraryLogger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let walletLibraryVCSDKLogConsumer = WalletLibraryVCSDKLogConsumer(logger: walletLibraryLogger)
+        
+        // Act
+        walletLibraryVCSDKLogConsumer.log(.ERROR,
+                                          message: mockMessage,
+                                          functionName: mockFunctionName,
+                                          file: mockFile,
+                                          line: mockLine)
+    }
+    
+    func testlog_WithFailure_LogsInWalletLibraryLogger() async throws {
+        // Arrange
+        let testLogConsumer = testLogConsumer(with: .FAILURE)
+        let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
+        let walletLibraryLogger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let walletLibraryVCSDKLogConsumer = WalletLibraryVCSDKLogConsumer(logger: walletLibraryLogger)
+        
+        // Act
+        walletLibraryVCSDKLogConsumer.log(.FAILURE,
+                                          message: mockMessage,
+                                          functionName: mockFunctionName,
+                                          file: mockFile,
+                                          line: mockLine)
+    }
+    
+    func testlog_WithWarn_LogsInWalletLibraryLogger() async throws {
+        // Arrange
+        let testLogConsumer = testLogConsumer(with: .WARN)
+        let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
+        let walletLibraryLogger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let walletLibraryVCSDKLogConsumer = WalletLibraryVCSDKLogConsumer(logger: walletLibraryLogger)
+        
+        // Act
+        walletLibraryVCSDKLogConsumer.log(.WARN,
+                                          message: mockMessage,
+                                          functionName: mockFunctionName,
+                                          file: mockFile,
+                                          line: mockLine)
+    }
+    
+    func testlog_WithVerbose_LogsInWalletLibraryLogger() async throws {
+        // Arrange
+        let testLogConsumer = testLogConsumer(with: .VERBOSE)
+        let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
+        let walletLibraryLogger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let walletLibraryVCSDKLogConsumer = WalletLibraryVCSDKLogConsumer(logger: walletLibraryLogger)
+        
+        // Act
+        walletLibraryVCSDKLogConsumer.log(.VERBOSE,
+                                          message: mockMessage,
+                                          functionName: mockFunctionName,
+                                          file: mockFile,
+                                          line: mockLine)
+    }
+    
+    func testevent_WithMessage_LogsEventInWalletLibraryLogger() async throws {
+        // Arrange
+        let mockName = "mock message"
+        func eventCalled(name: String) {
+            XCTAssertEqual(name, mockName)
+        }
+        
+        let mockWalletLibraryLogConsumer = MockLogConsumer(eventCallback: eventCalled)
+        let walletLibraryLogger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let walletLibraryVCSDKLogConsumer = WalletLibraryVCSDKLogConsumer(logger: walletLibraryLogger)
+        
+        // Act
+        walletLibraryVCSDKLogConsumer.event(name: mockName,
+                                            properties: nil,
+                                            measurements: nil)
+    }
+}


### PR DESCRIPTION
- Inject logger into VC SDK in builder.
- Add test cases for above.
- Update test scheme to enable code coverage.
- Fix type in README