### PR TITLE
Surface error thrown from Constraints logic

### DIFF
--- a/WalletLibrary/WalletLibrary/Protocols/Requests/Constraints/VerifiedIdConstraint.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Requests/Constraints/VerifiedIdConstraint.swift
@@ -6,8 +6,11 @@
 /**
  * A constraint on a requirement that defines a behavior of determining whether a VerifiedId
  * matches that constraint or not.
- * TODO: add method that throws an error to get more information about why constraint was not met.
  */
 protocol VerifiedIdConstraint {
+    /// Returns true if Verified Id matches the constrant. Else, false.
     func doesMatch(verifiedId: VerifiedId) -> Bool
+    
+    /// Throws an error if constraint is not met that explains why constraint is not met.
+    func matches(verifiedId: VerifiedId) throws
 }

--- a/WalletLibrary/WalletLibrary/Requests/Constraints/VCTypeConstraint.swift
+++ b/WalletLibrary/WalletLibrary/Requests/Constraints/VCTypeConstraint.swift
@@ -3,6 +3,10 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
+enum VCTypeConstraintError: Error, Equatable {
+    case verifiedIdDoesNotHaveSpecifiedType(String)
+}
+
 /**
  * A Verifiable Credential specific constraint that checks to see if the VC's type matches a value.
  */
@@ -16,5 +20,11 @@ struct VCTypeConstraint: VerifiedIdConstraint {
         }
         
         return verifiableCredential.types.contains(where: { $0 == type })
+    }
+    
+    func matches(verifiedId: VerifiedId) throws {
+        guard doesMatch(verifiedId: verifiedId) else {
+            throw VCTypeConstraintError.verifiedIdDoesNotHaveSpecifiedType(type)
+        }
     }
 }

--- a/WalletLibrary/WalletLibrary/Requests/Requirements/VerifiedIdRequirement.swift
+++ b/WalletLibrary/WalletLibrary/Requests/Requirements/VerifiedIdRequirement.swift
@@ -4,7 +4,6 @@
 *--------------------------------------------------------------------------------------------*/
 
 enum VerifiedIdRequirementError: Error {
-    case verifiedIdDoesNotMeetConstraints
     case requirementHasNotBeenFulfilled
 }
 

--- a/WalletLibrary/WalletLibrary/Requests/Requirements/VerifiedIdRequirement.swift
+++ b/WalletLibrary/WalletLibrary/Requests/Requirements/VerifiedIdRequirement.swift
@@ -60,8 +60,10 @@ public class VerifiedIdRequirement: Requirement {
             return Result.failure(VerifiedIdRequirementError.requirementHasNotBeenFulfilled)
         }
         
-        guard constraint.doesMatch(verifiedId: selectedVerifiedId) else {
-            return Result.failure(VerifiedIdRequirementError.verifiedIdDoesNotMeetConstraints)
+        do {
+            try constraint.matches(verifiedId: selectedVerifiedId)
+        } catch {
+            return Result.failure(error)
         }
         
         return Result.success(())
@@ -79,8 +81,10 @@ public class VerifiedIdRequirement: Requirement {
     /// the Verified Id does not satisfy the requirement.
     public func fulfill(with verifiedId: VerifiedId) -> Result<Void, Error> {
         
-        guard constraint.doesMatch(verifiedId: verifiedId) else {
-            return Result.failure(VerifiedIdRequirementError.verifiedIdDoesNotMeetConstraints)
+        do {
+            try constraint.matches(verifiedId: verifiedId)
+        } catch {
+            return Result.failure(error)
         }
         
         self.selectedVerifiedId = verifiedId

--- a/WalletLibrary/WalletLibraryTests/Mocks/Requests/Constraints/MockConstraint.swift
+++ b/WalletLibrary/WalletLibraryTests/Mocks/Requests/Constraints/MockConstraint.swift
@@ -7,13 +7,31 @@
 
 struct MockConstraint: VerifiedIdConstraint {
     
+    enum MockConstraintError: Error {
+        case expectedToThrow
+    }
+    
     let doesMatchResult: Bool
     
-    init(doesMatchResult: Bool) {
+    let matchesError: Error?
+    
+    init(doesMatchResult: Bool, matchesError: Error? = nil) {
         self.doesMatchResult = doesMatchResult
+        /// If does not match, always throw something.
+        if !doesMatchResult {
+            self.matchesError = matchesError ?? MockConstraintError.expectedToThrow
+        } else {
+            self.matchesError = nil
+        }
     }
     
     func doesMatch(verifiedId: WalletLibrary.VerifiedId) -> Bool {
         return doesMatchResult
+    }
+    
+    func matches(verifiedId: WalletLibrary.VerifiedId) throws {
+        if let matchesError = matchesError {
+            throw matchesError
+        }
     }
 }

--- a/WalletLibrary/WalletLibraryTests/Requests/Constraints/GroupConstraintTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Requests/Constraints/GroupConstraintTests.swift
@@ -18,7 +18,7 @@ class GroupConstraintTests: XCTestCase {
         let thirdConstraint = MockConstraint(doesMatchResult: true)
         let constraints = [firstConstraint, secondConstraint, thirdConstraint]
         let groupConstraint = GroupConstraint(constraints: constraints,
-                                                        constraintOperator: .ALL)
+                                              constraintOperator: .ALL)
         
         // Act / Assert
         XCTAssert(groupConstraint.doesMatch(verifiedId: mockVerifiedId))
@@ -32,7 +32,7 @@ class GroupConstraintTests: XCTestCase {
         let thirdConstraint = MockConstraint(doesMatchResult: true)
         let constraints = [firstConstraint, secondConstraint, thirdConstraint]
         let groupConstraint = GroupConstraint(constraints: constraints,
-                                                        constraintOperator: .ALL)
+                                              constraintOperator: .ALL)
         
         // Act / Assert
         XCTAssertFalse(groupConstraint.doesMatch(verifiedId: mockVerifiedId))
@@ -46,7 +46,7 @@ class GroupConstraintTests: XCTestCase {
         let thirdConstraint = MockConstraint(doesMatchResult: true)
         let constraints = [firstConstraint, secondConstraint, thirdConstraint]
         let groupConstraint = GroupConstraint(constraints: constraints,
-                                                        constraintOperator: .ANY)
+                                              constraintOperator: .ANY)
         
         // Act / Assert
         XCTAssert(groupConstraint.doesMatch(verifiedId: mockVerifiedId))
@@ -60,9 +60,87 @@ class GroupConstraintTests: XCTestCase {
         let thirdConstraint = MockConstraint(doesMatchResult: false)
         let constraints = [firstConstraint, secondConstraint, thirdConstraint]
         let groupConstraint = GroupConstraint(constraints: constraints,
-                                                        constraintOperator: .ANY)
+                                              constraintOperator: .ANY)
         
         // Act / Assert
         XCTAssertFalse(groupConstraint.doesMatch(verifiedId: mockVerifiedId))
+    }
+    
+    func testMatches_WithALLOperatorAndAllMatch_DoesNotThrow() throws {
+        // Arrange
+        let mockVerifiedId = MockVerifiedId(id: "mock verified id", issuedOn: Date())
+        let firstConstraint = MockConstraint(doesMatchResult: true)
+        let secondConstraint = MockConstraint(doesMatchResult: true)
+        let thirdConstraint = MockConstraint(doesMatchResult: true)
+        let constraints = [firstConstraint, secondConstraint, thirdConstraint]
+        let groupConstraint = GroupConstraint(constraints: constraints,
+                                              constraintOperator: .ALL)
+        
+        // Act / Assert
+        XCTAssertNoThrow(try groupConstraint.matches(verifiedId: mockVerifiedId))
+    }
+    
+    func testMatches_WithALLOperatorAndOneDoesNotMatch_ThrowsError() throws {
+        // Arrange
+        let mockVerifiedId = MockVerifiedId(id: "mock verified id", issuedOn: Date())
+        let firstConstraint = MockConstraint(doesMatchResult: true)
+        let secondConstraint = MockConstraint(doesMatchResult: false)
+        let thirdConstraint = MockConstraint(doesMatchResult: true)
+        let constraints = [firstConstraint, secondConstraint, thirdConstraint]
+        let groupConstraint = GroupConstraint(constraints: constraints,
+                                              constraintOperator: .ALL)
+        
+        // Act
+        XCTAssertThrowsError(try groupConstraint.matches(verifiedId: mockVerifiedId)) { error in
+            // Assert
+            XCTAssert(error is GroupConstraintError)
+            switch (error as? GroupConstraintError) {
+            case .atleastOneConstraintDoesNotMatch(errors: let errors):
+                for err in errors {
+                    XCTAssertEqual(err as? MockConstraint.MockConstraintError, .expectedToThrow)
+                }
+            default:
+                XCTFail()
+            }
+        }
+    }
+    
+    func testMatches_WithANYOperatorAndOneMatches_DoesNotThrow() throws {
+        // Arrange
+        let mockVerifiedId = MockVerifiedId(id: "mock verified id", issuedOn: Date())
+        let firstConstraint = MockConstraint(doesMatchResult: false)
+        let secondConstraint = MockConstraint(doesMatchResult: false)
+        let thirdConstraint = MockConstraint(doesMatchResult: true)
+        let constraints = [firstConstraint, secondConstraint, thirdConstraint]
+        let groupConstraint = GroupConstraint(constraints: constraints,
+                                              constraintOperator: .ANY)
+        
+        // Act / Assert
+        XCTAssertNoThrow(try groupConstraint.matches(verifiedId: mockVerifiedId))
+    }
+    
+    func testMatches_WithANYOperatorAndNoneMatch_ThrowsError() throws {
+        // Arrange
+        let mockVerifiedId = MockVerifiedId(id: "mock verified id", issuedOn: Date())
+        let firstConstraint = MockConstraint(doesMatchResult: false)
+        let secondConstraint = MockConstraint(doesMatchResult: false)
+        let thirdConstraint = MockConstraint(doesMatchResult: false)
+        let constraints = [firstConstraint, secondConstraint, thirdConstraint]
+        let groupConstraint = GroupConstraint(constraints: constraints,
+                                              constraintOperator: .ANY)
+        
+        // Act
+        XCTAssertThrowsError(try groupConstraint.matches(verifiedId: mockVerifiedId)) { error in
+            // Assert
+            XCTAssert(error is GroupConstraintError)
+            switch (error as? GroupConstraintError) {
+            case .noConstraintsMatch(errors: let errors):
+                for err in errors {
+                    XCTAssertEqual(err as? MockConstraint.MockConstraintError, .expectedToThrow)
+                }
+            default:
+                XCTFail()
+            }
+        }
     }
 }

--- a/WalletLibrary/WalletLibraryTests/Requests/Constraints/VCTypeConstraintTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Requests/Constraints/VCTypeConstraintTests.swift
@@ -59,4 +59,26 @@ class VCTypeConstraintTests: XCTestCase {
         // Assert
         XCTAssertFalse(result)
     }
+    
+    func testMatches_WhenVCDoesNotContainType_ThrowsError() throws {
+        // Arrange
+        let constraint = VCTypeConstraint(type: "mockType")
+        let verifiableCredential = mockVerifiableCredentialHelper.createMockVerifiableCredential(expectedTypes: ["unmatchingType"])
+        
+        // Act
+        XCTAssertThrowsError(try constraint.matches(verifiedId: verifiableCredential)) { error in
+            // Assert
+            XCTAssert(error is VCTypeConstraintError)
+            XCTAssertEqual(error as? VCTypeConstraintError, .verifiedIdDoesNotHaveSpecifiedType("mockType"))
+        }
+    }
+    
+    func testMatches_WhenVCDoesContainType_DoesNotThrow() throws {
+        // Arrange
+        let constraint = VCTypeConstraint(type: "mockType")
+        let verifiableCredential = mockVerifiableCredentialHelper.createMockVerifiableCredential(expectedTypes: ["mockType"])
+        
+        // Act / Assert
+        XCTAssertNoThrow(try constraint.matches(verifiedId: verifiableCredential))
+    }
 }

--- a/WalletLibrary/WalletLibraryTests/Requests/Requirements/VerifiedIdRequirementTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Requests/Requirements/VerifiedIdRequirementTests.swift
@@ -44,8 +44,8 @@ class VerifiedIdRequirementTests: XCTestCase {
         // Act
         XCTAssertThrowsError(try requirement.validate().get()) { error in
             // Assert
-            XCTAssert(error is VerifiedIdRequirementError)
-            XCTAssertEqual(error as? VerifiedIdRequirementError, .verifiedIdDoesNotMeetConstraints)
+            XCTAssert(error is MockConstraint.MockConstraintError)
+            XCTAssertEqual(error as? MockConstraint.MockConstraintError, .expectedToThrow)
         }
     }
     
@@ -146,8 +146,8 @@ class VerifiedIdRequirementTests: XCTestCase {
         // Act
         XCTAssertThrowsError(try requirement.fulfill(with: mockVerifiedId).get()) { error in
             // Assert
-            XCTAssert(error is VerifiedIdRequirementError)
-            XCTAssertEqual(error as? VerifiedIdRequirementError, .verifiedIdDoesNotMeetConstraints)
+            XCTAssert(error is MockConstraint.MockConstraintError)
+            XCTAssertEqual(error as? MockConstraint.MockConstraintError, .expectedToThrow)
         }
     }
     


### PR DESCRIPTION
**Problem:**
When a developer tries to fulfill a Verified ID Requirement with a Verified ID that does not match the constraints, we need to surface a better error message for why the Verified ID cannot be used to fulfill the requirement. 


**Solution:**
Add a `matches` method in VerifiedIdConstraints protocol that will throw if the VerifiedID does not match the constraint with a specific error.


**Validation:**
All unit tests pass.


**Type of change:**
- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.