### PR TITLE
Add new interface in Builder that enables keychain identifier injection.

### DIFF
--- a/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
@@ -12,6 +12,8 @@
  */
 public class VerifiedIdClientBuilder {
     
+    var keychainAccessGroupIdentifier: String?
+    
     private var logger: WalletLibraryLogger
     
     private var requestResolvers: [any RequestResolving] = []
@@ -24,9 +26,10 @@ public class VerifiedIdClientBuilder {
 
     /// Builds the VerifiedIdClient with the set configuration from the builder.
     public func build() -> VerifiedIdClient {
-        /// TODO: access group identifier into vc sdk.
+
         let vcLogConsumer = WalletLibraryVCSDKLogConsumer(logger: logger)
-        let _ = VerifiableCredentialSDK.initialize(logConsumer: vcLogConsumer)
+        let _ = VerifiableCredentialSDK.initialize(logConsumer: vcLogConsumer,
+                                                   accessGroupIdentifier: keychainAccessGroupIdentifier)
         
         let configuration = LibraryConfiguration(logger: logger,
                                                  mapper: Mapper(),
@@ -46,6 +49,12 @@ public class VerifiedIdClientBuilder {
     /// Optional method to add a custom log consumer to VerifiedIdClient.
     public func with(logConsumer: WalletLibraryLogConsumer) -> VerifiedIdClientBuilder {
         logger.add(consumer: logConsumer)
+        return self
+    }
+    
+    /// Optional method to use the given value to specify what Keychain Access Group keys should be stored in.
+    public func with(keychainAccessGroupIdentifier: String) -> VerifiedIdClientBuilder {
+        self.keychainAccessGroupIdentifier = keychainAccessGroupIdentifier
         return self
     }
     

--- a/WalletLibrary/WalletLibraryTests/VerifiedIdClientBuilderTests.swift
+++ b/WalletLibrary/WalletLibraryTests/VerifiedIdClientBuilderTests.swift
@@ -24,6 +24,7 @@ class VerifiedIdClientBuilderTests: XCTestCase {
         XCTAssert(actualResult.configuration.logger.consumers.isEmpty)
         XCTAssert(actualResult.configuration.verifiedIdDecoder is VerifiedIdDecoder)
         XCTAssert(actualResult.configuration.verifiedIdEncoder is VerifiedIdEncoder)
+        XCTAssertNil(builder.keychainAccessGroupIdentifier)
     }
     
     func testBuild_WithOneLogConsumer_ReturnsVerifiedIdClient() throws {
@@ -44,6 +45,7 @@ class VerifiedIdClientBuilderTests: XCTestCase {
         XCTAssert(actualResult.configuration.logger.consumers.contains { $0 is MockLogConsumer })
         XCTAssert(actualResult.configuration.verifiedIdDecoder is VerifiedIdDecoder)
         XCTAssert(actualResult.configuration.verifiedIdEncoder is VerifiedIdEncoder)
+        XCTAssertNil(builder.keychainAccessGroupIdentifier)
     }
     
     func testBuild_WithMultipleLogConsumers_ReturnsVerifiedIdClient() throws {
@@ -70,5 +72,27 @@ class VerifiedIdClientBuilderTests: XCTestCase {
         XCTAssert(actualResult.configuration.logger.consumers.contains { $0 as? MockLogConsumer == thirdLogConsumer })
         XCTAssert(actualResult.configuration.verifiedIdDecoder is VerifiedIdDecoder)
         XCTAssert(actualResult.configuration.verifiedIdEncoder is VerifiedIdEncoder)
+        XCTAssertNil(builder.keychainAccessGroupIdentifier)
+    }
+    
+    func testWithKeyChainIdentifier_WithValueInjected_ReturnsVerifiedIdClient() throws {
+        // Arrange
+        let expectedKeychainAccessGroupIdentifier = "expected keychain access group identifier"
+        
+        // Act
+        let builder = VerifiedIdClientBuilder()
+            .with(keychainAccessGroupIdentifier: expectedKeychainAccessGroupIdentifier)
+        let actualResult = builder.build()
+        
+        // Assert
+        XCTAssertEqual(actualResult.requestHandlerFactory.requestHandlers.count, 1)
+        XCTAssert(actualResult.requestHandlerFactory.requestHandlers.contains { $0 is OpenIdRequestHandler })
+        XCTAssertEqual(actualResult.requestResolverFactory.resolvers.count, 1)
+        XCTAssert(actualResult.requestResolverFactory.resolvers.contains { $0 is OpenIdURLRequestResolver })
+        XCTAssert(actualResult.configuration.logger.consumers.isEmpty)
+        XCTAssert(actualResult.configuration.logger.consumers.isEmpty)
+        XCTAssert(actualResult.configuration.verifiedIdDecoder is VerifiedIdDecoder)
+        XCTAssert(actualResult.configuration.verifiedIdEncoder is VerifiedIdEncoder)
+        XCTAssertEqual(builder.keychainAccessGroupIdentifier, expectedKeychainAccessGroupIdentifier)
     }
 }


### PR DESCRIPTION
**Problem:**
Developer might want to inject their own Keychain Access Group Identifier into the library to enable the keys to be stored in a particular Access Group.


**Solution:**
Create an additional method on Builder that enables this value to be added.


**Validation:**
New test case was added and all tests pass.


**Type of change:**
- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.