### PR TITLE
Fix bug where redirect uri is required in id token requirement.

### DIFF
--- a/WalletLibrary/WalletLibrary/Extensions/Mappings/VCSDK/Issuance/IdTokenDescriptor+Mappable.swift
+++ b/WalletLibrary/WalletLibrary/Extensions/Mappings/VCSDK/Issuance/IdTokenDescriptor+Mappable.swift
@@ -3,10 +3,6 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-#if canImport(VCEntities)
-    import VCEntities
-#endif
-
 /**
  * An extension of the VCEntities.IdTokenDescriptor class to be able
  * to map IdTokenDescriptor to IdTokenRequirement.
@@ -20,14 +16,12 @@ extension IdTokenDescriptor: Mappable {
             throw MappingError.InvalidProperty(property:"configuration",
                                                in: String(describing: IdTokenDescriptor.self))
         }
-        
-        let redirectUri = try getRequiredProperty(property: redirectURI, propertyName: "redirectURI")
 
         return IdTokenRequirement(encrypted: encrypted ?? false,
                                   required: idTokenRequired ?? false,
                                   configuration: configuration,
                                   clientId: clientID,
-                                  redirectUri: redirectUri,
+                                  redirectUri: redirectURI,
                                   scope: scope)
     }
 }

--- a/WalletLibrary/WalletLibrary/Requests/Requirements/IdTokenRequirement.swift
+++ b/WalletLibrary/WalletLibrary/Requests/Requirements/IdTokenRequirement.swift
@@ -21,7 +21,7 @@ public class IdTokenRequirement: Requirement {
     public let clientId: String
     
     /// The redirect url used to get the id token through an authentication library.
-    public let redirectUri: String
+    public let redirectUri: String?
     
     /// The scope used to get the id token through an authentication library.
     public let scope: String?
@@ -38,7 +38,7 @@ public class IdTokenRequirement: Requirement {
          required: Bool,
          configuration: URL,
          clientId: String,
-         redirectUri: String,
+         redirectUri: String?,
          scope: String?) {
         self.encrypted = encrypted
         self.required = required

--- a/WalletLibrary/WalletLibraryTests/Extensions/Mappings/VCSDK/Issuance/IdTokenDescriptor+MappableTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Extensions/Mappings/VCSDK/Issuance/IdTokenDescriptor+MappableTests.swift
@@ -49,22 +49,6 @@ class IdTokenDescriptorMappingTests: XCTestCase {
         assertEqual(actualResult, expectedResult)
     }
     
-    func testMappingWithNoRedirectUrlPresentError() throws {
-        let input = IdTokenDescriptor(encrypted: false,
-                                      claims: [],
-                                      idTokenRequired: false,
-                                      configuration: expectedConfiguration,
-                                      clientID: expectedClientId,
-                                      redirectURI: nil,
-                                      scope: expectedScope)
-        
-        XCTAssertThrowsError(try mapper.map(input)) { error in
-            XCTAssert(error is MappingError)
-            XCTAssertEqual(error as? MappingError,
-                           .PropertyNotPresent(property: "redirectURI", in: String(describing: IdTokenDescriptor.self)))
-        }
-    }
-    
     func testMappingWithNoClientIdPresentError() throws {
         let input = IdTokenDescriptor(encrypted: false,
                                       claims: [],


### PR DESCRIPTION
**Problem:**
The redirect uri is optional in a id token descriptor in a contract that described an id token hint requirement.


**Solution:**
Remove the check that ensured the redirect uri is required.


**Validation:**
Will not fail when redirect uri is missing.


**Type of change:**
- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.