### PR TITLE
Make error properties public.

### DIFF
--- a/WalletLibrary/WalletLibrary/Errors/VerifiedIdError.swift
+++ b/WalletLibrary/WalletLibrary/Errors/VerifiedIdError.swift
@@ -6,9 +6,9 @@
 /// Base Error Protocol. Every error that is returned from the library is a VerifiedIdError.
 public class VerifiedIdError: LocalizedError, CustomStringConvertible, Encodable {
 
-    let message: String
-    let code: String
-    let correlationId: String?
+    public let message: String
+    public let code: String
+    public let correlationId: String?
     
     init(message: String, code: String, correlationId: String? = nil) {
         self.message = message

--- a/WalletLibrary/WalletLibrary/Errors/VerifiedIdErrors.swift
+++ b/WalletLibrary/WalletLibrary/Errors/VerifiedIdErrors.swift
@@ -55,9 +55,9 @@ enum VerifiedIdErrors {
 // MARK: Common Errors
 
 /// Thrown when an input such as Data in decoding method is not properly formed.
-class MalformedInputError: VerifiedIdError {
+public class MalformedInputError: VerifiedIdError {
     
-    let error: Error
+    public let error: Error
     
     fileprivate init(error: Error, correlationId: String?) {
         self.error = error
@@ -78,9 +78,9 @@ class MalformedInputError: VerifiedIdError {
 }
 
 /// Thrown when a requirement such as VerifiedIdRequirement is not properly met.
-class RequirementNotMetError: VerifiedIdError {
+public class RequirementNotMetError: VerifiedIdError {
     
-    let errors: [Error]?
+    public let errors: [Error]?
     
     fileprivate init(message: String, errors: [Error]? = nil, correlationId: String?) {
         self.errors = errors
@@ -101,9 +101,9 @@ class RequirementNotMetError: VerifiedIdError {
 }
 
 /// Wraps any error that is not caught by another VerifiedIdError before being returned outside library.
-class UnspecifiedVerifiedIdError: VerifiedIdError {
+public class UnspecifiedVerifiedIdError: VerifiedIdError {
     
-    let error: Error
+    public let error: Error
     
     init(error: Error, correlationId: String?) {
         self.error = error
@@ -124,11 +124,11 @@ class UnspecifiedVerifiedIdError: VerifiedIdError {
 }
 
 /// Thrown when there is a Networking Error within the library.
-class VerifiedIdNetworkingError: VerifiedIdError {
+public class VerifiedIdNetworkingError: VerifiedIdError {
     
-    let statusCode: Int?
-    let innerError: Error?
-    let retryable: Bool
+    public let statusCode: Int?
+    public let innerError: Error?
+    public let retryable: Bool
     
     fileprivate init(message: String,
                      code: String,


### PR DESCRIPTION
Make Common Error Classes public to enable to developer to use these classes to resolve issues.