### PR TITLE
Correction misinterpretation of Presentation Exchange for OpenID

### DIFF
--- a/Docs/PresentationExchange.md
+++ b/Docs/PresentationExchange.md
@@ -1,0 +1,114 @@
+# OpenID Presentation Exchange Request Processor
+[Presentation Exchange](https://identity.foundation/presentation-exchange/) is a data format defining the exchange of credentials. Combined with the [OpenID Connect Verifiable Presentations](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html) extension creates a complete verified id request and response flow.
+
+```mermaid
+classDiagram
+
+class OpenIdRawRequest {
+    - type: RequestType
+    - raw: Data?
+    - promptValueForIssuance: String
+}
+
+RawRequest --|> OpenIdRawRequest
+
+RawRequest ..> RequestHandling: uses
+RawRequest ..> RequestProcessor: uses
+
+<<interface>> RequestHandling
+class RequestHandling {
+    ~handle(input: RawRequest) VerifiedIdRequest
+}
+
+class OpenIdRequestHandler {
+    - configuration: LibraryConfiguration
+    - openIdResponder: OpenIdResponder
+    - manifestResolver: ManifestResolver
+    - verifiedIdRequester: VerifiedIdRequester
+    ~handleRequest(request: RawRequest): VerifiedIdRequest
+}
+
+class OpenIdPresentationRequest {
+    - rawRequest: OpenIdRawRequest
+    - responder: OpenIdResponder
+    - configuration: LibraryConfiguration
+}
+OpenIdPresentationRequest ..> PresentationResponseContainer: uses
+
+class VerifiedIdRequirement {
+    - encrypted: Bool
+    - required: Bool 
+    - types: [String]
+    - purpose: String?
+    - issuanceOptions: [VerifiedIdRequestInput]
+    - id: String?
+    - constraint: VerifiedIdConstraint
+    - selectedVerifiedId: VerifiedId?
+    - exclusivePlacement: [String]
+    ~getMatches(verifeidIds: [VerifiedId]): [VerifiedId]
+    ~fulfill(verifiedId: VerifiedId): VerifiedIdResult<null>
+
+    ~exclusive(ids: [String])
+}
+
+class PresentationResponseContainer {
+    - request: PresentationRequest
+    - expiryInSeconds: Int
+    - audienceUrl: String
+    - audienceDid: String
+    - nonce: String
+    - requestedIdTokenMap: [:]
+    - requestedSelfAttestedClaimMap: [:]
+    - requestedVCMap: [:]
+    ~addVerifiableCredential(id: String, vc: VerifiableCredential)
+    ~add(requirement: Requirement)
+    
+}
+PresentationResponseContainer ..> VerifiedIdRequirement: uses
+
+OpenIdPresentationRequest o-- VerifiedIdRequirement
+
+VerifiedIdRequest --|> OpenIdPresentationRequest
+
+RequestHandling --|> OpenIdRequestHandler
+OpenIdRawRequest ..> OpenIdRequestHandler: uses
+
+class RequestProcessorFactory {
+    - requestProcessors: [RequestProcessor]
+    ~getRequestProcessor(for: RawRequest) RequestProcessor
+}
+<<Interface>> RequestProcessor
+class RequestProcessor {
+    ~canProcess(raw: RawRequest) Bool
+    ~process(raw: RawRequest) VerifiedIdRequest
+}
+
+class OpenIdPresentationExchangeRequestProcessor {
+    ~canProcess(raw: RawRequest) Bool
+    ~process(raw: RawRequest) VerifiedIdRequest
+}
+
+RequestProcessor --|> OpenIdPresentationExchangeRequestProcessor
+
+RequestProcessorFactory o-- OpenIdPresentationExchangeRequestProcessor
+OpenIdPresentationExchangeRequestProcessor ..> OpenIdPresentationRequest: creates
+OpenIdRequestHandler *-- RequestProcessorFactory
+<<Interface>> RawRequest
+<<Interface>> VerifiedIdRequest
+class VerifiedIdRequest {
+    - style: RequesterStyle
+    - requirement: Requirement
+    - rootOfTrust: RootOfTrust
+    ~isSatisfied(): Bool
+    ~complete(): VerifiedIdResult<T>
+    ~cancel(message: String?): VerifiedIdResult<null>
+}
+```
+
+`OpenIdPresentationExchangeRequestProcessor` can be called by `OpenIdRequestHandler` with the request. If the request is an `OpenIdRawRequest`, the processor will parse the `raw` value for a definition and form the corresponding `VerifiedIdRequest`.
+
+In parsing, it converts `input_definition`s into `VerifiedIdRequirement`s. `VerifiedIdRequirement` is fulfilled by supplying a `VerifiedId` that matches constraints.
+
+Once all `VerifiedIdRequirement`s have been satisfied, the OpenIdPresentationRequest can `complete()`. This will create a `PresentationResponseContainer` and `add` each requirement to the container. Once added, the container can be serialized, signed, and send according to the request's parameters.
+
+**Proposed Change**: `exclusivePlacement` can be added to `VerifiedIdRequirement` with `exclusive(with: [definition_id])` to ensure input definitions / requirements do not share the same verifiable presentation. `PresentationResponseContainer` will note these exclusions and any subject conflicts to create and map as many verifiable presentations as required.

--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCEntities/VCEntities/oidc/RequestedClaims.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCEntities/VCEntities/oidc/RequestedClaims.swift
@@ -7,24 +7,22 @@
 struct RequestedClaims: Codable, Equatable {
     
     /// Request Verifiable Presentation Tokens.
-    let vpToken: [RequestedVPToken]
+    let vpToken: RequestedVPToken
 
     enum CodingKeys: String, CodingKey {
         case vpToken = "vp_token"
     }
     
-    init(vpToken: [RequestedVPToken]) {
+    init(vpToken: RequestedVPToken) {
         self.vpToken = vpToken
     }
     
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        if let vpTokens = try? container.decode([RequestedVPToken].self, forKey: .vpToken) {
+        if let vpTokens = try? container.decode(RequestedVPToken.self, forKey: .vpToken) {
              self.vpToken = vpTokens
-        } else if let vpToken = try? container.decode(RequestedVPToken.self, forKey: .vpToken) {
-            self.vpToken = [vpToken]
-         } else {
+        } else {
              throw DecodingError.unableToDecodeToken
          }
     }

--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCEntities/VCEntities/presentation/PresentationResponseContainer.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCEntities/VCEntities/presentation/PresentationResponseContainer.swift
@@ -64,8 +64,7 @@ struct PresentationResponseContainer: ResponseContaining {
     
     mutating func addVerifiableCredential(id: String, vc: VerifiableCredential) throws {
         
-        guard let vpTokenRequest = request?.content.claims?.vpToken,
-              !vpTokenRequests else {
+        guard let vpTokenRequest = request?.content.claims?.vpToken else {
             throw PresentationResponseError.noVerifiablePresentationRequestsInRequest
         }
         

--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCEntities/VCEntities/presentation/PresentationResponseContainer.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCEntities/VCEntities/presentation/PresentationResponseContainer.swift
@@ -64,29 +64,26 @@ struct PresentationResponseContainer: ResponseContaining {
     
     mutating func addVerifiableCredential(id: String, vc: VerifiableCredential) throws {
         
-        guard let vpTokenRequests = request?.content.claims?.vpToken,
-              !vpTokenRequests.isEmpty else {
+        guard let vpTokenRequest = request?.content.claims?.vpToken,
+              !vpTokenRequests else {
             throw PresentationResponseError.noVerifiablePresentationRequestsInRequest
         }
         
-        for vpTokenRequest in vpTokenRequests {
+        guard let presentationDefinition = vpTokenRequest.presentationDefinition,
+                let presentationDefinitionId = presentationDefinition.id else {
+            throw PresentationResponseError.noPresentationDefinitionInVerifiablePresentationRequest
+        }
+        
+        if let inputDescriptors = presentationDefinition.inputDescriptors,
+            inputDescriptors.contains(where: { $0.id == id }) {
             
-            guard let presentationDefinition = vpTokenRequest.presentationDefinition,
-                  let presentationDefinitionId = presentationDefinition.id else {
-                throw PresentationResponseError.noPresentationDefinitionInVerifiablePresentationRequest
-            }
+            let mapping = RequestedVerifiableCredentialMapping(id: id, verifiableCredential: vc)
             
-            if let inputDescriptors = presentationDefinition.inputDescriptors,
-               inputDescriptors.contains(where: { $0.id == id }) {
-                
-                let mapping = RequestedVerifiableCredentialMapping(id: id, verifiableCredential: vc)
-                
-                var mappings = requestVCMap[presentationDefinitionId] ?? []
-                mappings.append(mapping)
-                
-                requestVCMap.updateValue(mappings, forKey: presentationDefinitionId)
-                return
-            }
+            var mappings = requestVCMap[presentationDefinitionId] ?? []
+            mappings.append(mapping)
+            
+            requestVCMap.updateValue(mappings, forKey: presentationDefinitionId)
+            return
         }
         
         throw PresentationResponseError.noInputDescriptorMatchesGivenId

--- a/WalletLibrary/WalletLibrary/Extensions/Mappings/VCSDK/Presentation/RequestedClaims+Mappable.swift
+++ b/WalletLibrary/WalletLibrary/Extensions/Mappings/VCSDK/Presentation/RequestedClaims+Mappable.swift
@@ -14,12 +14,9 @@ extension RequestedClaims: Mappable
     {
         var requirements: [Requirement] = []
         
-        for vpTokenRequest in vpToken
+        if let presentationDefinition = vpToken.presentationDefinition
         {
-            if let presentationDefinition = vpTokenRequest.presentationDefinition
-            {
-                requirements.append(contentsOf: try mapper.map(presentationDefinition))
-            }
+            requirements.append(contentsOf: try mapper.map(presentationDefinition))
         }
         
         if requirements.isEmpty


### PR DESCRIPTION
**Problem:**
While adding support for multiple vp_token responses, changes were made to parsing requests to allow multiple presentation definitions in the open_id request and treat each presentation definition as an independent vp_token. This change was not within specification and should be removed.


**Solution:**
Removed support for multiple presentation_definition objects in open id requests. 


**Validation:**
Manually validated against application code.


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:

**Documentation Links**:
https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-authorization-request