### PR TITLE
Expose verifiedId as a readonly field on verifiedIdRequirements

### DIFF
--- a/WalletLibrary/WalletLibrary/Requests/Requirements/VerifiedIdRequirement.swift
+++ b/WalletLibrary/WalletLibrary/Requests/Requirements/VerifiedIdRequirement.swift
@@ -23,6 +23,13 @@ public class VerifiedIdRequirement: Requirement {
     /// An optional property for information needed for issuance during presentation flow.
     public let issuanceOptions: [VerifiedIdRequestInput]
     
+    /// The verified id that fulfilled this requirement (if one exists)
+    public var verifiedId: VerifiedId? {
+        get {
+            return selectedVerifiedId
+        }
+    }
+    
     /// Optional id of requirement defined by the request.
     let id: String?
     


### PR DESCRIPTION
**Problem:**
Theres currently no easy way to read which verified ID has fulfilled a verified ID requirement.


**Solution:**
Added a public getter field to the verified id requirement to allow reading the verified ID (if one has fulfilled the requirement). 


**Validation:**
Integration testing with Authenticator.


**Type of change:**
- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:

**Documentation Links**: