### PR TITLE
Add internal (temp) Identifier Manager to Library Configuration.

### DIFF
--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/IdentifierService.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/IdentifierService.swift
@@ -3,21 +3,13 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-#if canImport(VCEntities)
-    import VCEntities
-#endif
-
-#if canImport(VCCrypto)
-    import VCCrypto
-#endif
-
 enum IdentifierServiceError: Error {
     case keyNotFoundInKeyStore(innerError: Error)
     case keyStoreError(message: String)
     case noKeysSavedForIdentifier
 }
 
-class IdentifierService {
+class IdentifierService: IdentifierManager {
     
     private let identifierDB: IdentifierDatabase
     private let identifierCreator: IdentifierCreator

--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		5524A5B629D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5524A5B529D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift */; };
 		5524A60C29D634BC00C5F18D /* VerifiedIdLogo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5524A5F629D634BC00C5F18D /* VerifiedIdLogo.swift */; };
 		5524A60E29D635A700C5F18D /* WalletLibraryLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5524A60D29D635A700C5F18D /* WalletLibraryLoggerTests.swift */; };
+		55265A492B61A7CD00BAD6A2 /* IdentifierManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55265A482B61A7CD00BAD6A2 /* IdentifierManager.swift */; };
 		552E509B293E6AB200868F47 /* WalletLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 552E5092293E6AB200868F47 /* WalletLibrary.framework */; };
 		552E50A0293E6AB200868F47 /* VerifiedIdClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552E509F293E6AB200868F47 /* VerifiedIdClientTests.swift */; };
 		552E50A1293E6AB200868F47 /* WalletLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = 552E5095293E6AB200868F47 /* WalletLibrary.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -521,6 +522,7 @@
 		5524A5B529D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLibraryVCSDKLogConsumerTests.swift; sourceTree = "<group>"; };
 		5524A5F629D634BC00C5F18D /* VerifiedIdLogo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerifiedIdLogo.swift; sourceTree = "<group>"; };
 		5524A60D29D635A700C5F18D /* WalletLibraryLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLibraryLoggerTests.swift; sourceTree = "<group>"; };
+		55265A482B61A7CD00BAD6A2 /* IdentifierManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierManager.swift; sourceTree = "<group>"; };
 		552E5092293E6AB200868F47 /* WalletLibrary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WalletLibrary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		552E5095293E6AB200868F47 /* WalletLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WalletLibrary.h; sourceTree = "<group>"; };
 		552E509A293E6AB200868F47 /* WalletLibraryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WalletLibraryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2539,6 +2541,7 @@
 				550E3215298B1224004E7716 /* Styles */,
 				5534E66C294A0F76005D0765 /* Utilities */,
 				55BA2DB429CDF9E000BB8207 /* VerifiedId */,
+				55265A482B61A7CD00BAD6A2 /* IdentifierManager.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -2923,6 +2926,7 @@
 				5552D40A29EF490A00B40302 /* PresentationExchangeConstraints.swift in Sources */,
 				5552D3B929EF487600B40302 /* FormatterError.swift in Sources */,
 				550E320E298B0FAC004E7716 /* WalletLibraryLogger.swift in Sources */,
+				55265A492B61A7CD00BAD6A2 /* IdentifierManager.swift in Sources */,
 				559BD3032995993700BD61AC /* PresentationInputDescriptor+Mappable.swift in Sources */,
 				55E337B52948B4B000CD2ED7 /* PinRequirement.swift in Sources */,
 				5552D3D929EF48B200B40302 /* IssuanceResponseContainer.swift in Sources */,

--- a/WalletLibrary/WalletLibrary/LibraryConfiguration.swift
+++ b/WalletLibrary/WalletLibrary/LibraryConfiguration.swift
@@ -18,16 +18,20 @@ class LibraryConfiguration {
     let verifiedIdEncoder: VerifiedIdEncoding
     
     let correlationHeader: VerifiedIdCorrelationHeader?
+    
+    let identifierManager: IdentifierManager
 
     init(logger: WalletLibraryLogger,
          mapper: Mapping,
          correlationHeader: VerifiedIdCorrelationHeader? = nil,
          verifiedIdDecoder: VerifiedIdDecoding = VerifiedIdDecoder(),
-         verifiedIdEncoder: VerifiedIdEncoding = VerifiedIdEncoder()) {
+         verifiedIdEncoder: VerifiedIdEncoding = VerifiedIdEncoder(),
+         identifierManager: IdentifierManager) {
         self.logger = logger
         self.mapper = mapper
         self.correlationHeader = correlationHeader
         self.verifiedIdDecoder = verifiedIdDecoder
         self.verifiedIdEncoder = verifiedIdEncoder
+        self.identifierManager = identifierManager
     }
 }

--- a/WalletLibrary/WalletLibrary/Protocols/IdentifierManager.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/IdentifierManager.swift
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+/// Manages all of the operations for Identifiers including fetching and storing.
+protocol IdentifierManager
+{
+    /// Fetch the main Identifier or create it if does not exist.
+    func fetchOrCreateMasterIdentifier() throws -> Identifier
+}

--- a/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
@@ -33,11 +33,15 @@ public class VerifiedIdClientBuilder {
         let _ = VerifiableCredentialSDK.initialize(logConsumer: vcLogConsumer,
                                                    accessGroupIdentifier: keychainAccessGroupIdentifier)
         
+        /// TODO: update to new Identifier logic once designed.
+        let identifierManager: IdentifierManager = VerifiableCredentialSDK.identifierService
+        
         let configuration = LibraryConfiguration(logger: logger,
                                                  mapper: Mapper(),
                                                  correlationHeader: correlationHeader,
                                                  verifiedIdDecoder: VerifiedIdDecoder(),
-                                                 verifiedIdEncoder: VerifiedIdEncoder())
+                                                 verifiedIdEncoder: VerifiedIdEncoder(),
+                                                 identifierManager: identifierManager)
         
         registerSupportedResolvers(with: configuration)
         registerSupportedRequestHandlers(with: configuration)


### PR DESCRIPTION
**Problem:**
We need to have access to Identifier DID to create nonce for ID Token Requirement.


**Solution:**
Create a temporary internal protocol `IdentifierManager` that the `IdentifierService` from VC SDK conforms to and add it to the library configuration to be used in the next pr to create the nonce.


**Validation:**
Small change.


**Type of change:**
- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.