### PR TITLE
Add preview feature flag support

### DIFF
--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		55265AD12B61B2B800BAD6A2 /* DataExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55265AD02B61B2B800BAD6A2 /* DataExtensionTests.swift */; };
 		55265AD32B61B6DE00BAD6A2 /* NonceCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55265AD22B61B6DE00BAD6A2 /* NonceCreatorTests.swift */; };
 		55265AD62B6C188200BAD6A2 /* PreviewFeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55265AD52B6C188200BAD6A2 /* PreviewFeatureFlags.swift */; };
+		55265AD82B6C267400BAD6A2 /* LibraryConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55265AD72B6C267300BAD6A2 /* LibraryConfigurationTests.swift */; };
 		552E509B293E6AB200868F47 /* WalletLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 552E5092293E6AB200868F47 /* WalletLibrary.framework */; };
 		552E50A0293E6AB200868F47 /* VerifiedIdClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552E509F293E6AB200868F47 /* VerifiedIdClientTests.swift */; };
 		552E50A1293E6AB200868F47 /* WalletLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = 552E5095293E6AB200868F47 /* WalletLibrary.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -532,6 +533,7 @@
 		55265AD02B61B2B800BAD6A2 /* DataExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtensionTests.swift; sourceTree = "<group>"; };
 		55265AD22B61B6DE00BAD6A2 /* NonceCreatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonceCreatorTests.swift; sourceTree = "<group>"; };
 		55265AD52B6C188200BAD6A2 /* PreviewFeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewFeatureFlags.swift; sourceTree = "<group>"; };
+		55265AD72B6C267300BAD6A2 /* LibraryConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryConfigurationTests.swift; sourceTree = "<group>"; };
 		552E5092293E6AB200868F47 /* WalletLibrary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WalletLibrary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		552E5095293E6AB200868F47 /* WalletLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WalletLibrary.h; sourceTree = "<group>"; };
 		552E509A293E6AB200868F47 /* WalletLibraryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WalletLibraryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1126,6 +1128,7 @@
 				55A81BF02991BB13002C259A /* Requests */,
 				55E3376929478C3300CD2ED7 /* Utilities */,
 				553CC09E29A97FD7005A5FD6 /* VerifiedId */,
+				55265AD72B6C267300BAD6A2 /* LibraryConfigurationTests.swift */,
 				559BD30C2996C12500BD61AC /* VerifiedIdClientBuilderTests.swift */,
 				552E509F293E6AB200868F47 /* VerifiedIdClientTests.swift */,
 			);
@@ -3170,6 +3173,7 @@
 				55BA2DD629CDFA4600BB8207 /* MockVerifiedIdEncoder.swift in Sources */,
 				559BD3052995AB8F00BD61AC /* PresentationDefinition+MappableTests.swift in Sources */,
 				5552D86C29F2E43A00B40302 /* DIDDocumentDecoderTests.swift in Sources */,
+				55265AD82B6C267400BAD6A2 /* LibraryConfigurationTests.swift in Sources */,
 				5524A5B629D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift in Sources */,
 				5552D85829F2E43900B40302 /* MockObject.swift in Sources */,
 				55A0DA482A74848D00BC178E /* PresentationExchangeFieldConstraintTests.swift in Sources */,

--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		55265ACF2B61B0D600BAD6A2 /* IdentifierManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55265ACE2B61B0D600BAD6A2 /* IdentifierManager.swift */; };
 		55265AD12B61B2B800BAD6A2 /* DataExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55265AD02B61B2B800BAD6A2 /* DataExtensionTests.swift */; };
 		55265AD32B61B6DE00BAD6A2 /* NonceCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55265AD22B61B6DE00BAD6A2 /* NonceCreatorTests.swift */; };
+		55265AD62B6C188200BAD6A2 /* PreviewFeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55265AD52B6C188200BAD6A2 /* PreviewFeatureFlags.swift */; };
 		552E509B293E6AB200868F47 /* WalletLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 552E5092293E6AB200868F47 /* WalletLibrary.framework */; };
 		552E50A0293E6AB200868F47 /* VerifiedIdClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552E509F293E6AB200868F47 /* VerifiedIdClientTests.swift */; };
 		552E50A1293E6AB200868F47 /* WalletLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = 552E5095293E6AB200868F47 /* WalletLibrary.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -530,6 +531,7 @@
 		55265ACE2B61B0D600BAD6A2 /* IdentifierManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifierManager.swift; sourceTree = "<group>"; };
 		55265AD02B61B2B800BAD6A2 /* DataExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtensionTests.swift; sourceTree = "<group>"; };
 		55265AD22B61B6DE00BAD6A2 /* NonceCreatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonceCreatorTests.swift; sourceTree = "<group>"; };
+		55265AD52B6C188200BAD6A2 /* PreviewFeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewFeatureFlags.swift; sourceTree = "<group>"; };
 		552E5092293E6AB200868F47 /* WalletLibrary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WalletLibrary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		552E5095293E6AB200868F47 /* WalletLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WalletLibrary.h; sourceTree = "<group>"; };
 		552E509A293E6AB200868F47 /* WalletLibraryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WalletLibraryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2565,6 +2567,7 @@
 				55A4BB322A29383A006836AB /* VerifiedIdResult.swift */,
 				55A0DA1B2A745E4100BC178E /* Dictionary+ValueExtraction.swift */,
 				5532753F2AF5A9930049A63F /* NonceCreator.swift */,
+				55265AD52B6C188200BAD6A2 /* PreviewFeatureFlags.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -2947,6 +2950,7 @@
 				5552D3EA29EF48E200B40302 /* RequestedVerifiableCredentialMapping.swift in Sources */,
 				5552D4D229EF4AC300B40302 /* CryptoOperating.swift in Sources */,
 				5552D3CC29EF48B200B40302 /* IssuanceCompletionResponse.swift in Sources */,
+				55265AD62B6C188200BAD6A2 /* PreviewFeatureFlags.swift in Sources */,
 				55A0DA1A2A7446B000BC178E /* PresentationExchangeFieldConstraint.swift in Sources */,
 				559BD3A6299AD9BD00BD61AC /* ManifestResolver.swift in Sources */,
 				55BA2DCD29CDF9E000BB8207 /* VerifiedIdEncoding.swift in Sources */,

--- a/WalletLibrary/WalletLibrary/LibraryConfiguration.swift
+++ b/WalletLibrary/WalletLibrary/LibraryConfiguration.swift
@@ -21,27 +21,27 @@ class LibraryConfiguration {
     
     let identifierManager: IdentifierManager
     
-    let previewFeatureFlagsSupported: [PreviewFeatureFlag]
+    let previewFeatureFlags: PreviewFeatureFlag
 
-    init(logger: WalletLibraryLogger,
-         mapper: Mapping,
+    init(logger: WalletLibraryLogger = WalletLibraryLogger(),
+         mapper: Mapping = Mapper(),
          correlationHeader: VerifiedIdCorrelationHeader? = nil,
          verifiedIdDecoder: VerifiedIdDecoding = VerifiedIdDecoder(),
          verifiedIdEncoder: VerifiedIdEncoding = VerifiedIdEncoder(),
          identifierManager: IdentifierManager? = nil,
-         previewFeatureFlagsSupported: [PreviewFeatureFlag] = []) {
+         previewFeatureFlags: PreviewFeatureFlag = PreviewFeatureFlag()) {
         self.logger = logger
         self.mapper = mapper
         self.correlationHeader = correlationHeader
         self.verifiedIdDecoder = verifiedIdDecoder
         self.verifiedIdEncoder = verifiedIdEncoder
         self.identifierManager = identifierManager ?? VerifiableCredentialSDK.identifierService
-        self.previewFeatureFlagsSupported = previewFeatureFlagsSupported
+        self.previewFeatureFlags = previewFeatureFlags
     }
     
     /// Helper function to determine if a preview feature flag is supported
-    func isPreviewFeatureFlagSupported(_ featureFlag: PreviewFeatureFlag) -> Bool
+    func isPreviewFeatureFlagSupported(_ featureFlag: String) -> Bool
     {
-        return previewFeatureFlagsSupported.contains(featureFlag)
+        return previewFeatureFlags.isPreviewFeatureSupported(featureFlag)
     }
 }

--- a/WalletLibrary/WalletLibrary/LibraryConfiguration.swift
+++ b/WalletLibrary/WalletLibrary/LibraryConfiguration.swift
@@ -20,18 +20,28 @@ class LibraryConfiguration {
     let correlationHeader: VerifiedIdCorrelationHeader?
     
     let identifierManager: IdentifierManager
+    
+    let previewFeatureFlagsSupported: [PreviewFeatureFlag]
 
     init(logger: WalletLibraryLogger,
          mapper: Mapping,
          correlationHeader: VerifiedIdCorrelationHeader? = nil,
          verifiedIdDecoder: VerifiedIdDecoding = VerifiedIdDecoder(),
          verifiedIdEncoder: VerifiedIdEncoding = VerifiedIdEncoder(),
-         identifierManager: IdentifierManager? = nil) {
+         identifierManager: IdentifierManager? = nil,
+         previewFeatureFlagsSupported: [PreviewFeatureFlag] = []) {
         self.logger = logger
         self.mapper = mapper
         self.correlationHeader = correlationHeader
         self.verifiedIdDecoder = verifiedIdDecoder
         self.verifiedIdEncoder = verifiedIdEncoder
         self.identifierManager = identifierManager ?? VerifiableCredentialSDK.identifierService
+        self.previewFeatureFlagsSupported = previewFeatureFlagsSupported
+    }
+    
+    /// Helper function to determine if a preview feature flag is supported
+    func isPreviewFeatureFlagSupported(_ featureFlag: PreviewFeatureFlag) -> Bool
+    {
+        return previewFeatureFlagsSupported.contains(featureFlag)
     }
 }

--- a/WalletLibrary/WalletLibrary/LibraryConfiguration.swift
+++ b/WalletLibrary/WalletLibrary/LibraryConfiguration.swift
@@ -21,7 +21,7 @@ class LibraryConfiguration {
     
     let identifierManager: IdentifierManager
     
-    let previewFeatureFlags: PreviewFeatureFlag
+    let previewFeatureFlags: PreviewFeatureFlags
 
     init(logger: WalletLibraryLogger = WalletLibraryLogger(),
          mapper: Mapping = Mapper(),
@@ -29,7 +29,7 @@ class LibraryConfiguration {
          verifiedIdDecoder: VerifiedIdDecoding = VerifiedIdDecoder(),
          verifiedIdEncoder: VerifiedIdEncoding = VerifiedIdEncoder(),
          identifierManager: IdentifierManager? = nil,
-         previewFeatureFlags: PreviewFeatureFlag = PreviewFeatureFlag()) {
+         previewFeatureFlags: PreviewFeatureFlags = PreviewFeatureFlags()) {
         self.logger = logger
         self.mapper = mapper
         self.correlationHeader = correlationHeader

--- a/WalletLibrary/WalletLibrary/Utilities/PreviewFeatureFlags.swift
+++ b/WalletLibrary/WalletLibrary/Utilities/PreviewFeatureFlags.swift
@@ -6,7 +6,7 @@
 /**
  * Feature Flags that can be used to support preview features that are still under development..
  */
-public struct PreviewFeatureFlag
+public struct PreviewFeatureFlags
 {
     /// A preview feature for access token support from the OpenID4VCI protocol.
     public static let OpenID4VCIAccessToken = "OpenID4VCIAccessToken"

--- a/WalletLibrary/WalletLibrary/Utilities/PreviewFeatureFlags.swift
+++ b/WalletLibrary/WalletLibrary/Utilities/PreviewFeatureFlags.swift
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+/**
+ * Feature Flags that can be used to support preview features that are still under development..
+ */
+public enum PreviewFeatureFlag 
+{
+    /// A preview feature for access token support from the OpenID4VCI protocol.
+    case OpenID4VCIAccessTokenSupport
+    
+    /// A preview feature for Pre Auth support from the OpenID4VCI protocol.
+    case OpenID4VCIPreAuthSupport
+}

--- a/WalletLibrary/WalletLibrary/Utilities/PreviewFeatureFlags.swift
+++ b/WalletLibrary/WalletLibrary/Utilities/PreviewFeatureFlags.swift
@@ -6,11 +6,29 @@
 /**
  * Feature Flags that can be used to support preview features that are still under development..
  */
-public enum PreviewFeatureFlag 
+public struct PreviewFeatureFlag
 {
     /// A preview feature for access token support from the OpenID4VCI protocol.
-    case OpenID4VCIAccessTokenSupport
+    public static let OpenID4VCIAccessToken = "OpenID4VCIAccessToken"
     
     /// A preview feature for Pre Auth support from the OpenID4VCI protocol.
-    case OpenID4VCIPreAuthSupport
+    public static let OpenID4VCIPreAuth = "OpenID4VCIPreAuth"
+    
+    private var supportedPreviewFeatures: [String: Bool] = [
+        OpenID4VCIAccessToken: false,
+        OpenID4VCIPreAuth: false
+    ]
+    
+    init(previewFeatureFlags: [String] = [])
+    {
+        for flag in previewFeatureFlags 
+        {
+            supportedPreviewFeatures[flag] = true
+        }
+    }
+    
+    func isPreviewFeatureSupported(_ featureFlag: String) -> Bool
+    {
+        return supportedPreviewFeatures[featureFlag] ?? false
+    }
 }

--- a/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
@@ -3,10 +3,6 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-#if canImport(VCServices)
-    import VCServices
-#endif
-
 /**
  * The VerifiedIdClientBuilder configures VerifiedIdClient with any additional options.
  */
@@ -21,6 +17,8 @@ public class VerifiedIdClientBuilder {
     private var requestResolvers: [any RequestResolving] = []
     
     private var requestHandlers: [any RequestHandling] = []
+    
+    private var previewFeatureFlagsSupported: [PreviewFeatureFlag] = []
     
     public init() {
         logger = WalletLibraryLogger()
@@ -41,7 +39,8 @@ public class VerifiedIdClientBuilder {
                                                  correlationHeader: correlationHeader,
                                                  verifiedIdDecoder: VerifiedIdDecoder(),
                                                  verifiedIdEncoder: VerifiedIdEncoder(),
-                                                 identifierManager: identifierManager)
+                                                 identifierManager: identifierManager,
+                                                 previewFeatureFlagsSupported: previewFeatureFlagsSupported)
         
         registerSupportedResolvers(with: configuration)
         registerSupportedRequestHandlers(with: configuration)
@@ -51,6 +50,13 @@ public class VerifiedIdClientBuilder {
         return VerifiedIdClient(requestResolverFactory: requestResolverFactory,
                                 requestHandlerFactory: requestHandlerFactory,
                                 configuration: configuration)
+    }
+    
+    /// Optional method to add support for preview features.
+    public func with(previewFeatureFlags: [PreviewFeatureFlag]) -> VerifiedIdClientBuilder
+    {
+        previewFeatureFlagsSupported.append(contentsOf: previewFeatureFlags)
+        return self
     }
 
     /// Optional method to add a custom log consumer to VerifiedIdClient.

--- a/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
@@ -27,7 +27,7 @@ public class VerifiedIdClientBuilder {
     /// Builds the VerifiedIdClient with the set configuration from the builder.
     public func build() -> VerifiedIdClient {
 
-        let previewFeatureFlags = PreviewFeatureFlag(previewFeatureFlags: previewFeatureFlagsSupported)
+        let previewFeatureFlags = PreviewFeatureFlags(previewFeatureFlags: previewFeatureFlagsSupported)
         let vcLogConsumer = WalletLibraryVCSDKLogConsumer(logger: logger)
         let _ = VerifiableCredentialSDK.initialize(logConsumer: vcLogConsumer,
                                                    accessGroupIdentifier: keychainAccessGroupIdentifier)

--- a/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
@@ -18,7 +18,7 @@ public class VerifiedIdClientBuilder {
     
     private var requestHandlers: [any RequestHandling] = []
     
-    private var previewFeatureFlagsSupported: [PreviewFeatureFlag] = []
+    private var previewFeatureFlagsSupported: [String] = []
     
     public init() {
         logger = WalletLibraryLogger()
@@ -27,6 +27,7 @@ public class VerifiedIdClientBuilder {
     /// Builds the VerifiedIdClient with the set configuration from the builder.
     public func build() -> VerifiedIdClient {
 
+        let previewFeatureFlags = PreviewFeatureFlag(previewFeatureFlags: previewFeatureFlagsSupported)
         let vcLogConsumer = WalletLibraryVCSDKLogConsumer(logger: logger)
         let _ = VerifiableCredentialSDK.initialize(logConsumer: vcLogConsumer,
                                                    accessGroupIdentifier: keychainAccessGroupIdentifier)
@@ -40,7 +41,7 @@ public class VerifiedIdClientBuilder {
                                                  verifiedIdDecoder: VerifiedIdDecoder(),
                                                  verifiedIdEncoder: VerifiedIdEncoder(),
                                                  identifierManager: identifierManager,
-                                                 previewFeatureFlagsSupported: previewFeatureFlagsSupported)
+                                                 previewFeatureFlags: previewFeatureFlags)
         
         registerSupportedResolvers(with: configuration)
         registerSupportedRequestHandlers(with: configuration)
@@ -53,7 +54,7 @@ public class VerifiedIdClientBuilder {
     }
     
     /// Optional method to add support for preview features.
-    public func with(previewFeatureFlags: [PreviewFeatureFlag]) -> VerifiedIdClientBuilder
+    public func with(previewFeatureFlags: [String]) -> VerifiedIdClientBuilder
     {
         previewFeatureFlagsSupported.append(contentsOf: previewFeatureFlags)
         return self

--- a/WalletLibrary/WalletLibraryTests/LibraryConfigurationTests.swift
+++ b/WalletLibrary/WalletLibraryTests/LibraryConfigurationTests.swift
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import XCTest
+@testable import WalletLibrary
+
+class LibraryConfigurationTests: XCTestCase {
+    
+    func testIsPreviewFeatureSupported_WhenFeatureIsSupported_ReturnTrue() async throws {
+        // Arrange
+        let mockFeatureFlag = "MockFeatureFlag"
+        let previewFeatureFlag = PreviewFeatureFlag(previewFeatureFlags: [mockFeatureFlag])
+        let configuration = LibraryConfiguration(previewFeatureFlags: previewFeatureFlag)
+        
+        // Act / Arrange
+        XCTAssert(configuration.isPreviewFeatureFlagSupported(mockFeatureFlag))
+    }
+    
+    func testIsPreviewFeatureSupported_WhenFeatureDoesNotExist_ReturnFalse() async throws {
+        // Arrange
+        let mockFeatureFlag = "MockFeatureFlag"
+        let configuration = LibraryConfiguration()
+        
+        // Act / Arrange
+        XCTAssertFalse(configuration.isPreviewFeatureFlagSupported(mockFeatureFlag))
+    }
+}

--- a/WalletLibrary/WalletLibraryTests/LibraryConfigurationTests.swift
+++ b/WalletLibrary/WalletLibraryTests/LibraryConfigurationTests.swift
@@ -11,7 +11,7 @@ class LibraryConfigurationTests: XCTestCase {
     func testIsPreviewFeatureSupported_WhenFeatureIsSupported_ReturnTrue() async throws {
         // Arrange
         let mockFeatureFlag = "MockFeatureFlag"
-        let previewFeatureFlag = PreviewFeatureFlag(previewFeatureFlags: [mockFeatureFlag])
+        let previewFeatureFlag = PreviewFeatureFlags(previewFeatureFlags: [mockFeatureFlag])
         let configuration = LibraryConfiguration(previewFeatureFlags: previewFeatureFlag)
         
         // Act / Arrange

--- a/WalletLibrary/WalletLibraryTests/VerifiedIdClientBuilderTests.swift
+++ b/WalletLibrary/WalletLibraryTests/VerifiedIdClientBuilderTests.swift
@@ -119,4 +119,27 @@ class VerifiedIdClientBuilderTests: XCTestCase {
         XCTAssertEqual(actualResult.configuration.correlationHeader?.name, name)
         XCTAssertEqual(actualResult.configuration.correlationHeader?.value, value)
     }
+    
+    func testBuild_WithPreviewFlagInjection_ReturnsVerifiedIdClient() throws {
+        // Arrange
+        let mockPreviewFeature = "mockPreviewFeature"
+        let unsupportedPreviewFeature = "unsupportedPreviewFeature"
+        
+        // Act
+        let builder = VerifiedIdClientBuilder()
+            .with(previewFeatureFlags: [mockPreviewFeature])
+        let actualResult = builder.build()
+        
+        // Assert
+        XCTAssertEqual(actualResult.requestHandlerFactory.requestHandlers.count, 1)
+        XCTAssert(actualResult.requestHandlerFactory.requestHandlers.contains { $0 is OpenIdRequestHandler })
+        XCTAssertEqual(actualResult.requestResolverFactory.resolvers.count, 1)
+        XCTAssert(actualResult.requestResolverFactory.resolvers.contains { $0 is OpenIdURLRequestResolver })
+        XCTAssert(actualResult.configuration.logger.consumers.isEmpty)
+        XCTAssert(actualResult.configuration.logger.consumers.isEmpty)
+        XCTAssert(actualResult.configuration.verifiedIdDecoder is VerifiedIdDecoder)
+        XCTAssert(actualResult.configuration.verifiedIdEncoder is VerifiedIdEncoder)
+        XCTAssert(actualResult.configuration.isPreviewFeatureFlagSupported(mockPreviewFeature))
+        XCTAssertFalse(actualResult.configuration.isPreviewFeatureFlagSupported(unsupportedPreviewFeature))
+    }
 }


### PR DESCRIPTION
**Problem:**
We need to turn off/on preview features that are still under development.


**Solution:**
Add the ability to inject Preview Feature Flags in VerifiedIdClientBuilder to support those features.


**Validation:**
Unit tests pass.


**Type of change:**
- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.