### PR TITLE
Update PodSpec to support 1.0.0 and newer versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can use cocoapods to install the Wallet Library by adding it to your Podfile
 
 target "YourApp" do
   use_frameworks!
-  pod "WalletLibrary", "~> 0.0.1"
+  pod "WalletLibrary", "~> 0.0.1", :submodules => true
 end
 ```
 > note: use_frameworks! is required for this Pod.
@@ -158,4 +158,3 @@ Any use of third-party trademarks or logos are subject to those third-party's po
 [badge-platforms]: https://img.shields.io/badge/platforms-iOS-lightgrey.svg
 [badge-license]: https://img.shields.io/github/license/microsoft/entra-verifiedid-wallet-library-ios
 [badge-azure-pipline]: https://decentralized-identity.visualstudio.com/Core/_apis/build/status/iOS%20Wallet%20Library?branchName=dev
-[badge-privatepreview]: https://img.shields.io/badge/status-Private%20Preview-red.svg

--- a/WalletLibrary.podspec
+++ b/WalletLibrary.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.source= {
     :git => 'https://github.com/microsoft/entra-verifiedid-wallet-library-ios.git',
     :submodules => true,
-    :tag => '1.0.0'
+    :tag => s.version
   }
 
   vcsdkPath = 'WalletLibrary/Submodules/VerifiableCredential-SDK-iOS'

--- a/WalletLibrary.podspec
+++ b/WalletLibrary.podspec
@@ -1,129 +1,97 @@
 Pod::Spec.new do |s|
-    s.name= 'WalletLibrary'
-    s.version= '1.0.0'
-    s.license= 'MIT'
-    s.summary= 'An SDK to manage your Decentralized Identities and Verifiable Credentials.'
-    s.homepage= 'https://github.com/microsoft/entra-verifiedid-wallet-library-ios'
-    s.authors= {
-      'symorton' => 'symorton@microsoft.com'
-    }
-    s.documentation_url= 'https://github.com/microsoft/entra-verifiedid-wallet-library-ios'
-    s.source= {
-      :git => 'https://github.com/microsoft/entra-verifiedid-wallet-library-ios.git',
-      :submodules => true,
-      :tag => s.version
-    }
+  s.name= 'WalletLibrary'
+  s.version= '1.0.0'
+  s.license= 'MIT'
+  s.summary= 'An SDK to manage your Decentralized Identities and Verifiable Credentials.'
+  s.homepage= 'https://github.com/microsoft/entra-verifiedid-wallet-library-ios'
+  s.authors= {
+    'symorton' => 'symorton@microsoft.com'
+  }
+  s.documentation_url= 'https://github.com/microsoft/entra-verifiedid-wallet-library-ios'
+  s.source= {
+    :git => 'https://github.com/microsoft/entra-verifiedid-wallet-library-ios.git',
+    :submodules => true,
+    :tag => '1.0.0'
+  }
 
-    vcsdkPath = 'WalletLibrary/Submodules/VerifiableCredential-SDK-iOS'
-    submodulePath = 'WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/Submodules'
+  vcsdkPath = 'WalletLibrary/Submodules/VerifiableCredential-SDK-iOS'
+  submodulePath = 'WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/Submodules'
 
-    s.swift_version = '5.0'
+  s.swift_version = '5.0'
 
-    s.ios.deployment_target = '13.0'
-    s.default_subspecs = 'Core'
+  s.ios.deployment_target = '13.0'
+  s.default_subspecs = 'Core'
 
-    s.subspec 'Secp256k1' do |cs|
-        cs.library = 'c++'
-        cs.public_header_files = ["#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/include/*"]
-        cs.compiler_flags = "-Wno-shorten-64-to-32", "-Wno-unused-function"
-        cs.preserve_paths = "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/{include,src}/*.{c,h}"
-        cs.source_files = ["#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/{include,src}/*.{c,h}"]
-        cs.exclude_files = [  
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/bench.c",
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/bench_ecdh.c",
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/bench_ecmult.c",
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/bench_internal.c",
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/bench_recover.c",
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/bench_schnorrsig.c",
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/bench_sign.c",
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/bench_verify.c",
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/tests.c",
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/testrand_impl.h",
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/testrand.h",
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/valgrind_ctime_test.c",
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/ctime_tests.c",
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/gen_context.c",
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/precompute_ecmult_gen.c",
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/tests_exhaustive.c",
-          "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/contrib/*.{c, h}"
-       ]
-        cs.prefix_header_contents = '
-  #define ECMULT_WINDOW_SIZE 15 
-  #define LIBSECP256K1_CONFIG_H
-  #define USE_NUM_NONE 1 
-  #define ECMULT_WINDOW_SIZE 15
-  #define ECMULT_GEN_PREC_BITS 4
-  #define USE_FIELD_INV_BUILTIN 1
-  #define USE_SCALAR_INV_BUILTIN 1
-  #define HAVE_DLFCN_H 1
-  #define HAVE_INTTYPES_H 1
-  #define HAVE_MEMORY_H 1
-  #define HAVE_STDINT_H 1
-  #define HAVE_STDLIB_H 1
-  #define HAVE_STRINGS_H 1
-  #define HAVE_STRING_H 1
-  #define HAVE_SYS_STAT_H 1
-  #define HAVE_SYS_TYPES_H 1
-  #define HAVE_UNISTD_H 1
-  #define LT_OBJDIR ".libs/"
-  #define PACKAGE "libsecp256k1"
-  #define PACKAGE_BUGREPORT ""
-  #define PACKAGE_NAME "libsecp256k1"
-  #define PACKAGE_STRING "libsecp256k1 0.1"
-  #define PACKAGE_TARNAME "libsecp256k1"
-  #define PACKAGE_URL ""
-  #define PACKAGE_VERSION "0.1"
-  #define STDC_HEADERS 1
-  #define VERSION "0.1"'
-    end
+  s.subspec 'Secp256k1' do |cs|
+      cs.library = 'c++'
+      cs.public_header_files = ["#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/include/*"]
+      cs.compiler_flags = "-Wno-shorten-64-to-32", "-Wno-unused-function"
+      cs.preserve_paths = "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/{include,src}/*.{c,h}"
+      cs.source_files = ["#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/{include,src}/*.{c,h}"]
+      cs.exclude_files = [  
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/bench.c",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/bench_ecdh.c",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/bench_ecmult.c",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/bench_internal.c",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/bench_recover.c",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/bench_schnorrsig.c",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/bench_sign.c",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/bench_verify.c",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/tests.c",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/testrand_impl.h",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/testrand.h",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/valgrind_ctime_test.c",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/ctime_tests.c",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/gen_context.c",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/precompute_ecmult.c",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/precompute_ecmult_gen.c",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/src/tests_exhaustive.c",
+        "#{submodulePath}/Secp256k1/bitcoin-core/secp256k1/contrib/*.{c, h}"
+     ]
+      cs.prefix_header_contents = '
+#define ECMULT_WINDOW_SIZE 15 
+#define LIBSECP256K1_CONFIG_H
+#define USE_NUM_NONE 1 
+#define ECMULT_WINDOW_SIZE 15
+#define ECMULT_GEN_PREC_BITS 4
+#define USE_FIELD_INV_BUILTIN 1
+#define USE_SCALAR_INV_BUILTIN 1
+#define HAVE_DLFCN_H 1
+#define HAVE_INTTYPES_H 1
+#define HAVE_MEMORY_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STRINGS_H 1
+#define HAVE_STRING_H 1
+#define HAVE_SYS_STAT_H 1
+#define HAVE_SYS_TYPES_H 1
+#define HAVE_UNISTD_H 1
+#define LT_OBJDIR ".libs/"
+#define PACKAGE "libsecp256k1"
+#define PACKAGE_BUGREPORT ""
+#define PACKAGE_NAME "libsecp256k1"
+#define PACKAGE_STRING "libsecp256k1 0.1"
+#define PACKAGE_TARNAME "libsecp256k1"
+#define PACKAGE_URL ""
+#define PACKAGE_VERSION "0.1"
+#define STDC_HEADERS 1
+#define VERSION "0.1"'
+  end
 
-    s.subspec 'VCCrypto' do |cs|
-        cs.name = 'VCCrypto'
-        cs.preserve_paths = "#{vcsdkPath}/VCCrypto/**/*.swift"
-        cs.source_files= "#{vcsdkPath}/VCCrypto/VCCrypto/**/*.swift"
-        cs.dependency 'WalletLibrary/Secp256k1'
-    end 
-
-    s.subspec 'VCToken' do |cs|
-        cs.name = 'VCToken'
-        cs.preserve_paths = "#{vcsdkPath}/VCToken/**/*.swift"
-        cs.source_files= "#{vcsdkPath}/VCToken/VCToken/**/*.swift"
-        cs.dependency 'WalletLibrary/VCCrypto'
-    end
-
-
-    s.subspec 'VCEntities' do |cs|
-        cs.name = 'VCEntities'
-        cs.preserve_paths = "#{vcsdkPath}/VCEntities/**/*.swift"
-        cs.source_files= "#{vcsdkPath}/VCEntities/VCEntities/**/*.swift"
-        cs.dependency 'WalletLibrary/VCToken'
-        cs.dependency 'WalletLibrary/VCCrypto'
-    end
-
-    s.subspec 'VCNetworking' do |cs|
-        cs.name = 'VCNetworking'
-        cs.preserve_paths = "#{vcsdkPath}/VCNetworking/**/*.swift"
-        cs.source_files= "#{vcsdkPath}/VCNetworking/VCNetworking/**/*.swift"
-        cs.dependency 'WalletLibrary/VCEntities'
-    end
-
-    s.subspec 'VCServices' do |cs|
-        cs.name = 'VCServices'
-        cs.preserve_paths = "#{vcsdkPath}/VCServices/**/*.{swift, xcdatamodeld, xcdatamodel}"
-        cs.source_files= "#{vcsdkPath}/VCServices/VCServices/**/*.{swift, xcdatamodeld, xcdatamodel}"
-        cs.resources = [
-            "#{vcsdkPath}/VCServices/VCServices/Resources/coreData/VerifiableCredentialDataModel.xcdatamodeld",
-            "#{vcsdkPath}/VCServices/VCServices/Resources/coreData/VerifiableCredentialDataModel.xcdatamodeld/*.xcdatamodel"]
-        cs.preserve_paths = "#{vcsdkPath}/VCServices/VCServices/Resources/coreData/VerifiableCredentialDataModel.xcdatamodeld"
-        cs.dependency 'WalletLibrary/VCNetworking'
-        cs.dependency 'WalletLibrary/VCEntities'
-    end
-
-    s.subspec 'Core' do |cs|
-        cs.name = 'Core'
-        cs.preserve_paths = "WalletLibrary/WalletLibrary/**/*.swift"
-        cs.source_files= "WalletLibrary/WalletLibrary/**/*.swift"
-        cs.dependency 'WalletLibrary/VCServices'
-        cs.dependency 'WalletLibrary/VCEntities'
-    end
+  s.subspec 'Core' do |cs|
+      cs.name = 'Core'
+      cs.source_files= [
+          "WalletLibrary/WalletLibrary/**/*.swift",
+          "#{vcsdkPath}/VCServices/VCServices/**/*.{swift, xcdatamodeld, xcdatamodel}",
+          "#{vcsdkPath}/VCNetworking/VCNetworking/**/*.swift",
+          "#{vcsdkPath}/VCEntities/VCEntities/**/*.swift",
+          "#{vcsdkPath}/VCToken/VCToken/**/*.swift",
+          "#{vcsdkPath}/VCCrypto/VCCrypto/**/*.swift"
+      ]
+      cs.resources = "#{vcsdkPath}/VCServices/VCServices/Resources/**/*.{xcdatamodeld,xcdatamodel,mom,momd}"
+      cs.exclude_files = [
+          "WalletLibrary/**/*Test/*.swift"
+      ]
+      cs.dependency 'WalletLibrary/Secp256k1'
+  end
 end


### PR DESCRIPTION
**Problem:**
As the VC SDK's functionality gets moved into newer components, the subspecs design of the current PodSpec will break the pod spec validation.


**Solution:**
- Move all VC SDK components (except Secp256k1) into the Core subspec to not break current release and support new releases in the future.
- Add documentation to tell developer to use the submodule: true command in their Podfile


**Validation:**
PodSpec passes validation and works in a Sample App.


**Type of change:**
- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.