### PR TITLE
Simplify Post Operation in Wallet Library and create OpenID4VCIPostOperation

### DIFF
--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -377,6 +377,7 @@
 		5552D9A829F2F1B900B40302 /* Secp256k1.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5552D98729F2F17F00B40302 /* Secp256k1.framework */; platformFilter = ios; };
 		555FB16A2B73FBB000EE14BD /* CredentialOfferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB1692B73FBB000EE14BD /* CredentialOfferTests.swift */; };
 		555FB1B62B740A3000EE14BD /* OpenId4VCIHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB1B52B740A3000EE14BD /* OpenId4VCIHandlerTests.swift */; };
+		555FB22E2B7AC1A800EE14BD /* OpenID4VCIPostOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB22D2B7AC1A800EE14BD /* OpenID4VCIPostOperation.swift */; };
 		5585BDE729A6C38C0059710B /* InjectedIdToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5585BDE629A6C38C0059710B /* InjectedIdToken.swift */; };
 		5598CFCD2AAF8DD600EBDE87 /* RequestedClaimsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5598CFCC2AAF8DD600EBDE87 /* RequestedClaimsTests.swift */; };
 		5598CFD22AAF8E7500EBDE87 /* PresentationResponseContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5598CFD12AAF8E7500EBDE87 /* PresentationResponseContainerTests.swift */; };
@@ -892,6 +893,7 @@
 		5552D98229F2F17F00B40302 /* Secp256k1.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Secp256k1.xcodeproj; path = Secp256k1/Secp256k1.xcodeproj; sourceTree = "<group>"; };
 		555FB1692B73FBB000EE14BD /* CredentialOfferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialOfferTests.swift; sourceTree = "<group>"; };
 		555FB1B52B740A3000EE14BD /* OpenId4VCIHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenId4VCIHandlerTests.swift; sourceTree = "<group>"; };
+		555FB22D2B7AC1A800EE14BD /* OpenID4VCIPostOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenID4VCIPostOperation.swift; sourceTree = "<group>"; };
 		5585BDE629A6C38C0059710B /* InjectedIdToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectedIdToken.swift; sourceTree = "<group>"; };
 		5598CFCC2AAF8DD600EBDE87 /* RequestedClaimsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestedClaimsTests.swift; sourceTree = "<group>"; };
 		5598CFD12AAF8E7500EBDE87 /* PresentationResponseContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationResponseContainerTests.swift; sourceTree = "<group>"; };
@@ -1137,6 +1139,7 @@
 			children = (
 				55265B002B6D938800BAD6A2 /* OpenID4VCIRequestNetworkOperation.swift */,
 				55FE70812B730D1500CC3018 /* CredentialMetadataFetchOperation.swift */,
+				555FB22D2B7AC1A800EE14BD /* OpenID4VCIPostOperation.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -3152,6 +3155,7 @@
 				559BD414299D37B100BD61AC /* SelfIssuedClaimsDescriptor+Mappable.swift in Sources */,
 				5552D3B529EF486500B40302 /* RequestedClaims.swift in Sources */,
 				55A81BE12991AB96002C259A /* RequestHandling.swift in Sources */,
+				555FB22E2B7AC1A800EE14BD /* OpenID4VCIPostOperation.swift in Sources */,
 				5552D40029EF490000B40302 /* VPTokenResponseDescription.swift in Sources */,
 				55E2F071299554110008010D /* LibraryConfiguration.swift in Sources */,
 				55265B012B6D938800BAD6A2 /* OpenID4VCIRequestNetworkOperation.swift in Sources */,

--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -392,6 +392,7 @@
 		555FB2122B759FC200EE14BD /* MockIdentifierDocumentResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB2112B759FC200EE14BD /* MockIdentifierDocumentResolver.swift */; };
 		555FB2142B759FF100EE14BD /* MockRootOfTrustResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB2132B759FF100EE14BD /* MockRootOfTrustResolver.swift */; };
 		555FB2162B75A2A900EE14BD /* IdentifierDocumentResolving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB2152B75A2A900EE14BD /* IdentifierDocumentResolving.swift */; };
+		555FB23A2B7AD67600EE14BD /* OpenID4VCIPostOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB2392B7AD67600EE14BD /* OpenID4VCIPostOperation.swift */; };
 		5585BDE729A6C38C0059710B /* InjectedIdToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5585BDE629A6C38C0059710B /* InjectedIdToken.swift */; };
 		5598CFCD2AAF8DD600EBDE87 /* RequestedClaimsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5598CFCC2AAF8DD600EBDE87 /* RequestedClaimsTests.swift */; };
 		5598CFD22AAF8E7500EBDE87 /* PresentationResponseContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5598CFD12AAF8E7500EBDE87 /* PresentationResponseContainerTests.swift */; };
@@ -922,6 +923,7 @@
 		555FB2112B759FC200EE14BD /* MockIdentifierDocumentResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockIdentifierDocumentResolver.swift; sourceTree = "<group>"; };
 		555FB2132B759FF100EE14BD /* MockRootOfTrustResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRootOfTrustResolver.swift; sourceTree = "<group>"; };
 		555FB2152B75A2A900EE14BD /* IdentifierDocumentResolving.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierDocumentResolving.swift; sourceTree = "<group>"; };
+		555FB2392B7AD67600EE14BD /* OpenID4VCIPostOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenID4VCIPostOperation.swift; sourceTree = "<group>"; };
 		5585BDE629A6C38C0059710B /* InjectedIdToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectedIdToken.swift; sourceTree = "<group>"; };
 		5598CFCC2AAF8DD600EBDE87 /* RequestedClaimsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestedClaimsTests.swift; sourceTree = "<group>"; };
 		5598CFD12AAF8E7500EBDE87 /* PresentationResponseContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationResponseContainerTests.swift; sourceTree = "<group>"; };
@@ -1167,6 +1169,7 @@
 		55265AFF2B6D936900BAD6A2 /* Operations */ = {
 			isa = PBXGroup;
 			children = (
+				555FB2392B7AD67600EE14BD /* OpenID4VCIPostOperation.swift */,
 				55265B002B6D938800BAD6A2 /* OpenID4VCIRequestNetworkOperation.swift */,
 				55FE70812B730D1500CC3018 /* CredentialMetadataFetchOperation.swift */,
 			);
@@ -3049,6 +3052,7 @@
 				5552D45529EF4A8100B40302 /* SimpleFailureHandler.swift in Sources */,
 				5552D3A829EF483900B40302 /* ResponseContaining.swift in Sources */,
 				55DECC2E29BB8DA800D5C802 /* GroupConstraint.swift in Sources */,
+				555FB23A2B7AD67600EE14BD /* OpenID4VCIPostOperation.swift in Sources */,
 				5552D4D029EF4AC300B40302 /* VCSDKConfigurable.swift in Sources */,
 				5552D3C329EF489400B40302 /* IONDocumentPatch.swift in Sources */,
 				5534E667294A0B6C005D0765 /* Mappable.swift in Sources */,

--- a/WalletLibrary/WalletLibrary/Networking/Operations/CredentialMetadataFetchOperation.swift
+++ b/WalletLibrary/WalletLibrary/Networking/Operations/CredentialMetadataFetchOperation.swift
@@ -10,19 +10,6 @@ struct CredentialMetadataFetchOperation: WalletLibraryFetchOperation
 {
     typealias ResponseBody = CredentialMetadata
     
-    /// The decoder for the Credential Metadata.
-    struct CredentialMetadataDecoder: Decoding
-    {
-        typealias ResponseBody = CredentialMetadata
-        
-        func decode(data: Data) throws -> CredentialMetadata
-        {
-            return try JSONDecoder().decode(CredentialMetadata.self, from: data)
-        }
-    }
-    
-    var decoder = CredentialMetadataDecoder()
-    
     var urlSession: URLSession
     
     var urlRequest: URLRequest

--- a/WalletLibrary/WalletLibrary/Networking/Operations/OpenID4VCIPostOperation.swift
+++ b/WalletLibrary/WalletLibrary/Networking/Operations/OpenID4VCIPostOperation.swift
@@ -11,7 +11,7 @@ struct OpenID4VCIPostOperation: WalletLibraryPostOperation
     typealias RequestBody = RawOpenID4VCIRequest
     typealias ResponseBody = RawOpenID4VCIResponse
     
-    var urlSession: URLSession
+    let urlSession: URLSession
     
     var urlRequest: URLRequest
     

--- a/WalletLibrary/WalletLibrary/Networking/Operations/OpenID4VCIPostOperation.swift
+++ b/WalletLibrary/WalletLibrary/Networking/Operations/OpenID4VCIPostOperation.swift
@@ -8,32 +8,8 @@
  */
 struct OpenID4VCIPostOperation: WalletLibraryPostOperation
 {
-    typealias Encoder = RawOpenID4VCIRequestEncoder
-    
-    typealias ResponseBody = RawOpenID4VCIResponse
-    
     typealias RequestBody = RawOpenID4VCIRequest
-    
-    /// The decoder for the Credential Metadata.
-    struct RawOpenID4VCIResponseDecoder: Decoding
-    {
-        func decode(data: Data) throws -> RawOpenID4VCIResponse
-        {
-            return try JSONDecoder().decode(RawOpenID4VCIResponse.self,
-                                            from: data)
-        }
-    }
-    
-    /// The decoder for the Credential Metadata.
-    struct RawOpenID4VCIRequestEncoder: Encoding
-    {
-        func encode(value: RawOpenID4VCIRequest) throws -> Data {
-            return try JSONEncoder().encode(value)
-        }
-    }
-    
-    
-    var decoder = RawOpenID4VCIResponseDecoder()
+    typealias ResponseBody = RawOpenID4VCIResponse
     
     var urlSession: URLSession
     
@@ -45,7 +21,8 @@ struct OpenID4VCIPostOperation: WalletLibraryPostOperation
          url: URL,
          additionalHeaders: [String : String]?,
          urlSession: URLSession,
-         correlationVector: VerifiedIdCorrelationHeader?) {
+         correlationVector: VerifiedIdCorrelationHeader?) 
+    {
         
         self.urlSession = urlSession
         self.correlationVector = correlationVector
@@ -59,4 +36,3 @@ struct OpenID4VCIPostOperation: WalletLibraryPostOperation
         addHeadersToURLRequest(headers: additionalHeaders)
     }
 }
-

--- a/WalletLibrary/WalletLibrary/Networking/Operations/OpenID4VCIPostOperation.swift
+++ b/WalletLibrary/WalletLibrary/Networking/Operations/OpenID4VCIPostOperation.swift
@@ -29,7 +29,6 @@ struct OpenID4VCIPostOperation: WalletLibraryPostOperation
         self.urlRequest = URLRequest(url: url)
         
         /// Adds value to prefer header, appending if value already exists.
-        /// Adds value to prefer header, appending if value already exists.
         let preferHeader = [OpenID4VCINetworkConstants.PreferHeaderField: OpenID4VCINetworkConstants.InteropProfileVersion]
         addHeadersToURLRequest(headers: preferHeader)
         

--- a/WalletLibrary/WalletLibrary/Networking/Operations/OpenID4VCIPostOperation.swift
+++ b/WalletLibrary/WalletLibrary/Networking/Operations/OpenID4VCIPostOperation.swift
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+/**
+ * The Network Operation for the Credential Metadata fetch request.
+ */
+struct OpenID4VCIPostOperation: WalletLibraryPostOperation
+{
+    typealias Encoder = RawOpenID4VCIRequestEncoder
+    
+    typealias ResponseBody = RawOpenID4VCIResponse
+    
+    typealias RequestBody = RawOpenID4VCIRequest
+    
+    /// The decoder for the Credential Metadata.
+    struct RawOpenID4VCIResponseDecoder: Decoding
+    {
+        func decode(data: Data) throws -> RawOpenID4VCIResponse
+        {
+            return try JSONDecoder().decode(RawOpenID4VCIResponse.self,
+                                            from: data)
+        }
+    }
+    
+    /// The decoder for the Credential Metadata.
+    struct RawOpenID4VCIRequestEncoder: Encoding
+    {
+        func encode(value: RawOpenID4VCIRequest) throws -> Data {
+            return try JSONEncoder().encode(value)
+        }
+    }
+    
+    
+    var decoder = RawOpenID4VCIResponseDecoder()
+    
+    var urlSession: URLSession
+    
+    var urlRequest: URLRequest
+    
+    var correlationVector: VerifiedIdCorrelationHeader?
+    
+    init(requestBody: RawOpenID4VCIRequest, 
+         url: URL,
+         additionalHeaders: [String : String]?,
+         urlSession: URLSession,
+         correlationVector: VerifiedIdCorrelationHeader?) {
+        
+        self.urlSession = urlSession
+        self.correlationVector = correlationVector
+        self.urlRequest = URLRequest(url: url)
+        
+        /// Adds value to prefer header, appending if value already exists.
+        /// Adds value to prefer header, appending if value already exists.
+        let preferHeader = [OpenID4VCINetworkConstants.PreferHeaderField: OpenID4VCINetworkConstants.InteropProfileVersion]
+        addHeadersToURLRequest(headers: preferHeader)
+        
+        addHeadersToURLRequest(headers: additionalHeaders)
+    }
+}
+

--- a/WalletLibrary/WalletLibrary/Protocols/Networking/WalletLibraryNetworkingOperations.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Networking/WalletLibraryNetworkingOperations.swift
@@ -6,12 +6,22 @@
 /**
  * The Wallet Library Fetch Operation.
  */
-protocol WalletLibraryFetchOperation: InternalNetworkOperation
+protocol WalletLibraryFetchOperation: InternalNetworkOperation where ResponseBody: Decodable
 {
+    associatedtype Decoder = SimpleDecoder<ResponseBody>
+    
     init(url: URL,
          additionalHeaders: [String: String]?,
          urlSession: URLSession,
          correlationVector: VerifiedIdCorrelationHeader?)
+}
+
+extension WalletLibraryFetchOperation
+{
+    var decoder: SimpleDecoder<ResponseBody>
+    {
+        SimpleDecoder()
+    }
 }
 
 /**

--- a/WalletLibrary/WalletLibrary/Protocols/Networking/WalletLibraryNetworkingOperations.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Networking/WalletLibraryNetworkingOperations.swift
@@ -16,6 +16,10 @@ protocol WalletLibraryFetchOperation: InternalNetworkOperation where ResponseBod
          correlationVector: VerifiedIdCorrelationHeader?)
 }
 
+/**
+ * An extension for the `WalletLibraryFetchOperation` to have a simple decoder
+ * that just decodes JSON by default.
+ */
 extension WalletLibraryFetchOperation
 {
     var decoder: SimpleDecoder<ResponseBody>
@@ -39,6 +43,10 @@ protocol WalletLibraryPostOperation: InternalPostOperation where ResponseBody: D
          correlationVector: VerifiedIdCorrelationHeader?)
 }
 
+/**
+ * An extension for the `WalletLibraryPostOperation`
+ * to have a simple decoder and a simple encoder to handle JSON by default.
+ */
 extension WalletLibraryPostOperation
 {
     var encoder: SimpleEncoder<RequestBody>
@@ -52,6 +60,9 @@ extension WalletLibraryPostOperation
     }
 }
 
+/**
+ * A Simple Encoder to act as default to handle JSON.
+ */
 struct SimpleEncoder<T: Encodable>: Encoding
 {
     func encode(value: T) throws -> Data
@@ -60,6 +71,9 @@ struct SimpleEncoder<T: Encodable>: Encoding
     }
 }
 
+/**
+ * A Simple Decoder to act as default to handle JSON.
+ */
 struct SimpleDecoder<T: Decodable>: Decoding
 {
     func decode(data: Data) throws -> T

--- a/WalletLibrary/WalletLibrary/Protocols/Networking/WalletLibraryNetworkingOperations.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Networking/WalletLibraryNetworkingOperations.swift
@@ -17,7 +17,7 @@ protocol WalletLibraryFetchOperation: InternalNetworkOperation
 /**
  * The Wallet Library Post Operation.
  */
-protocol WalletLibraryPostOperation: PostNetworkOperation
+protocol WalletLibraryPostOperation: InternalPostOperation
 {
     init(requestBody: RequestBody,
          url: URL,

--- a/WalletLibrary/WalletLibrary/Protocols/Networking/WalletLibraryNetworkingOperations.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Networking/WalletLibraryNetworkingOperations.swift
@@ -17,13 +17,45 @@ protocol WalletLibraryFetchOperation: InternalNetworkOperation
 /**
  * The Wallet Library Post Operation.
  */
-protocol WalletLibraryPostOperation: InternalPostOperation
+protocol WalletLibraryPostOperation: InternalPostOperation where ResponseBody: Decodable, RequestBody: Encodable
 {
+    associatedtype Encoder = SimpleEncoder<RequestBody>
+    associatedtype Decoder = SimpleDecoder<ResponseBody>
+
     init(requestBody: RequestBody,
          url: URL,
          additionalHeaders: [String: String]?,
          urlSession: URLSession,
          correlationVector: VerifiedIdCorrelationHeader?)
+}
+
+extension WalletLibraryPostOperation
+{
+    var encoder: SimpleEncoder<RequestBody>
+    {
+        SimpleEncoder()
+    }
+    
+    var decoder: SimpleDecoder<ResponseBody>
+    {
+        SimpleDecoder()
+    }
+}
+
+struct SimpleEncoder<T: Encodable>: Encoding
+{
+    func encode(value: T) throws -> Data
+    {
+        try JSONEncoder().encode(value)
+    }
+}
+
+struct SimpleDecoder<T: Decodable>: Decoding
+{
+    func decode(data: Data) throws -> T
+    {
+        return try JSONDecoder().decode(T.self, from: data)
+    }
 }
 
 extension InternalNetworkOperation


### PR DESCRIPTION
**Problem:**
The networking layer can be simplified when the encoder and decoder are simply decoding/encoding JSON.

**Solution:**
- Add default Encoder and Decoders for JSON request/response bodies.
- Create network operation for issuance request using OpenID4VCI format.



**Validation:**
All unit tests pass as expected.


**Type of change:**
- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.