### PR TITLE
Add tests for RawOpenID4VCIRequestFormatter and new Verified ID type.

### DIFF
--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCToken/VCTokenTests/mocks/MockSigner.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCToken/VCTokenTests/mocks/MockSigner.swift
@@ -4,15 +4,33 @@
 *--------------------------------------------------------------------------------------------*/
 
 @testable import WalletLibrary
-import WalletLibrary
 
-class MockSigner: TokenSigning {
+class MockSigner: TokenSigning 
+{
+    enum ExpectedError: Error
+    {
+        case SignExpectedToThrow
+    }
     
-    func sign<T>(token: JwsToken<T>, withSecret secret: VCCryptoSecret) throws -> Signature where T : Claims {
+    private let doesSignThrow: Bool
+    
+    init(doesSignThrow: Bool = false)
+    {
+        self.doesSignThrow = doesSignThrow
+    }
+    
+    func sign<T : Claims>(token: JwsToken<T>, withSecret secret: VCCryptoSecret) throws -> Signature
+    {
+        if doesSignThrow
+        {
+            throw ExpectedError.SignExpectedToThrow
+        }
+        
         return "fakeSignature".data(using: .utf8)!
     }
     
-    func getPublicJwk(from secret: VCCryptoSecret, withKeyId keyId: String) throws -> ECPublicJwk {
+    func getPublicJwk(from secret: VCCryptoSecret, withKeyId keyId: String) throws -> ECPublicJwk 
+    {
         return ECPublicJwk(x: "x", y: "y", keyId: "keyId")
     }
     

--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -402,6 +402,7 @@
 		5585BDE729A6C38C0059710B /* InjectedIdToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5585BDE629A6C38C0059710B /* InjectedIdToken.swift */; };
 		558CF1A92B8680F600AF5D82 /* RawOpenID4VCIRequestFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558CF1A82B8680F600AF5D82 /* RawOpenID4VCIRequestFormatterTests.swift */; };
 		558CF1AB2B868ADF00AF5D82 /* MockIdentifierManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558CF1AA2B868ADF00AF5D82 /* MockIdentifierManager.swift */; };
+		558CF1AD2B869CDD00AF5D82 /* OpenID4VCIVerifiedIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558CF1AC2B869CDD00AF5D82 /* OpenID4VCIVerifiedIDTests.swift */; };
 		5598CFCD2AAF8DD600EBDE87 /* RequestedClaimsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5598CFCC2AAF8DD600EBDE87 /* RequestedClaimsTests.swift */; };
 		5598CFD22AAF8E7500EBDE87 /* PresentationResponseContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5598CFD12AAF8E7500EBDE87 /* PresentationResponseContainerTests.swift */; };
 		5598CFD42AAF931E00EBDE87 /* PresentationResponseEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5598CFD32AAF931E00EBDE87 /* PresentationResponseEncoderTests.swift */; };
@@ -941,6 +942,7 @@
 		5585BDE629A6C38C0059710B /* InjectedIdToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectedIdToken.swift; sourceTree = "<group>"; };
 		558CF1A82B8680F600AF5D82 /* RawOpenID4VCIRequestFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawOpenID4VCIRequestFormatterTests.swift; sourceTree = "<group>"; };
 		558CF1AA2B868ADF00AF5D82 /* MockIdentifierManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockIdentifierManager.swift; sourceTree = "<group>"; };
+		558CF1AC2B869CDD00AF5D82 /* OpenID4VCIVerifiedIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenID4VCIVerifiedIDTests.swift; sourceTree = "<group>"; };
 		5598CFCC2AAF8DD600EBDE87 /* RequestedClaimsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestedClaimsTests.swift; sourceTree = "<group>"; };
 		5598CFD12AAF8E7500EBDE87 /* PresentationResponseContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationResponseContainerTests.swift; sourceTree = "<group>"; };
 		5598CFD32AAF931E00EBDE87 /* PresentationResponseEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationResponseEncoderTests.swift; sourceTree = "<group>"; };
@@ -1385,6 +1387,7 @@
 		553CC09E29A97FD7005A5FD6 /* VerifiedId */ = {
 			isa = PBXGroup;
 			children = (
+				558CF1AC2B869CDD00AF5D82 /* OpenID4VCIVerifiedIDTests.swift */,
 				553CC09F29A98003005A5FD6 /* VCVerifiedIdTests.swift */,
 				55BA2DD829CDFA6100BB8207 /* VerifiedIdDecoderTests.swift */,
 				55BA2DD929CDFA6100BB8207 /* VerifiedIdEncoderTests.swift */,
@@ -3412,6 +3415,7 @@
 				5534E6AD294AAFA6005D0765 /* PresentationDescriptor+MappableTests.swift in Sources */,
 				5552D7D129F2E0AA00B40302 /* PbkdfTests.swift in Sources */,
 				559BD4ED299EEAD100BD61AC /* IdTokenRequirementTests.swift in Sources */,
+				558CF1AD2B869CDD00AF5D82 /* OpenID4VCIVerifiedIDTests.swift in Sources */,
 				5552D81629F2E25900B40302 /* MockTokenVerifier.swift in Sources */,
 				55DECC3D29BFE22900D5C802 /* OpenIdPresentationRequestTests.swift in Sources */,
 				55EA17AA29CA57320085E29E /* MockVerifiedIdStyle.swift in Sources */,

--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -400,6 +400,8 @@
 		555FB2442B7BCE4500EE14BD /* SignedCredentialMetadataProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB2432B7BCE4500EE14BD /* SignedCredentialMetadataProcessing.swift */; };
 		555FB2462B7BD20100EE14BD /* MockSignedMetadataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB2452B7BD20100EE14BD /* MockSignedMetadataProcessor.swift */; };
 		5585BDE729A6C38C0059710B /* InjectedIdToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5585BDE629A6C38C0059710B /* InjectedIdToken.swift */; };
+		558CF1A92B8680F600AF5D82 /* RawOpenID4VCIRequestFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558CF1A82B8680F600AF5D82 /* RawOpenID4VCIRequestFormatterTests.swift */; };
+		558CF1AB2B868ADF00AF5D82 /* MockIdentifierManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558CF1AA2B868ADF00AF5D82 /* MockIdentifierManager.swift */; };
 		5598CFCD2AAF8DD600EBDE87 /* RequestedClaimsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5598CFCC2AAF8DD600EBDE87 /* RequestedClaimsTests.swift */; };
 		5598CFD22AAF8E7500EBDE87 /* PresentationResponseContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5598CFD12AAF8E7500EBDE87 /* PresentationResponseContainerTests.swift */; };
 		5598CFD42AAF931E00EBDE87 /* PresentationResponseEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5598CFD32AAF931E00EBDE87 /* PresentationResponseEncoderTests.swift */; };
@@ -937,6 +939,8 @@
 		555FB2432B7BCE4500EE14BD /* SignedCredentialMetadataProcessing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedCredentialMetadataProcessing.swift; sourceTree = "<group>"; };
 		555FB2452B7BD20100EE14BD /* MockSignedMetadataProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSignedMetadataProcessor.swift; sourceTree = "<group>"; };
 		5585BDE629A6C38C0059710B /* InjectedIdToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectedIdToken.swift; sourceTree = "<group>"; };
+		558CF1A82B8680F600AF5D82 /* RawOpenID4VCIRequestFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawOpenID4VCIRequestFormatterTests.swift; sourceTree = "<group>"; };
+		558CF1AA2B868ADF00AF5D82 /* MockIdentifierManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockIdentifierManager.swift; sourceTree = "<group>"; };
 		5598CFCC2AAF8DD600EBDE87 /* RequestedClaimsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestedClaimsTests.swift; sourceTree = "<group>"; };
 		5598CFD12AAF8E7500EBDE87 /* PresentationResponseContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationResponseContainerTests.swift; sourceTree = "<group>"; };
 		5598CFD32AAF931E00EBDE87 /* PresentationResponseEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationResponseEncoderTests.swift; sourceTree = "<group>"; };
@@ -2337,6 +2341,7 @@
 		555FB1662B73FB5500EE14BD /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				558CF1A72B8680E100AF5D82 /* Formatters */,
 				555FB1672B73FB6300EE14BD /* Entities */,
 			);
 			path = Networking;
@@ -2408,6 +2413,14 @@
 				555FB2132B759FF100EE14BD /* MockRootOfTrustResolver.swift */,
 			);
 			path = RootOfTrust;
+			sourceTree = "<group>";
+		};
+		558CF1A72B8680E100AF5D82 /* Formatters */ = {
+			isa = PBXGroup;
+			children = (
+				558CF1A82B8680F600AF5D82 /* RawOpenID4VCIRequestFormatterTests.swift */,
+			);
+			path = Formatters;
 			sourceTree = "<group>";
 		};
 		5598CFCA2AAF8DBC00EBDE87 /* oidc */ = {
@@ -2593,6 +2606,7 @@
 				55A81C0B2991BF73002C259A /* Requests */,
 				55DECC3E29BFEACB00D5C802 /* MockVerifiableCredentialHelper.swift */,
 				55508A4A2A3B954100186885 /* MockVerifiedIdError.swift */,
+				558CF1AA2B868ADF00AF5D82 /* MockIdentifierManager.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -3393,6 +3407,7 @@
 				55E2F08429955E8A0008010D /* MockMapper.swift in Sources */,
 				55E2F06F299553B40008010D /* OpenIdRequestHandlerTests.swift in Sources */,
 				5552D7EE29F2E1AF00B40302 /* ClaimsTest.swift in Sources */,
+				558CF1A92B8680F600AF5D82 /* RawOpenID4VCIRequestFormatterTests.swift in Sources */,
 				5552D7F129F2E1AF00B40302 /* ECPublicJwkTests.swift in Sources */,
 				5534E6AD294AAFA6005D0765 /* PresentationDescriptor+MappableTests.swift in Sources */,
 				5552D7D129F2E0AA00B40302 /* PbkdfTests.swift in Sources */,
@@ -3434,6 +3449,7 @@
 				559BD30D2996C12500BD61AC /* VerifiedIdClientBuilderTests.swift in Sources */,
 				55DECBD029B922D200D5C802 /* MockPresentationResponder.swift in Sources */,
 				550A91952994025C0014D030 /* OpenIdURLRequestResolverTests.swift in Sources */,
+				558CF1AB2B868ADF00AF5D82 /* MockIdentifierManager.swift in Sources */,
 				55BA2DD629CDFA4600BB8207 /* MockVerifiedIdEncoder.swift in Sources */,
 				559BD3052995AB8F00BD61AC /* PresentationDefinition+MappableTests.swift in Sources */,
 				5552D86C29F2E43A00B40302 /* DIDDocumentDecoderTests.swift in Sources */,

--- a/WalletLibrary/WalletLibraryTests/Mocks/MockIdentifierManager.swift
+++ b/WalletLibrary/WalletLibraryTests/Mocks/MockIdentifierManager.swift
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+@testable import WalletLibrary
+
+struct MockIdentifierManager: IdentifierManager
+{
+    enum ExpectedError: Error
+    {
+        case ExpectedToThrow
+    }
+    
+    let mockKeyId: String
+    
+    let doesThrow: Bool
+    
+    init(mockKeyId: String)
+    {
+        self.mockKeyId = mockKeyId
+        self.doesThrow = false
+    }
+    
+    init(doesThrow: Bool = false)
+    {
+        self.mockKeyId = "mockKeyId"
+        self.doesThrow = doesThrow
+    }
+    
+    func fetchOrCreateMasterIdentifier() throws -> Identifier
+    {
+        guard !doesThrow else
+        {
+            throw ExpectedError.ExpectedToThrow
+        }
+        
+        return mockIdentifier(keyId: mockKeyId)
+    }
+    
+    private func mockIdentifier(keyId: String) -> Identifier
+    {
+        let uuid = UUID()
+        let key = KeyContainer(keyReference: MockCryptoSecret(id: uuid), keyId: keyId)
+        let identifier = Identifier(longFormDid: "did:test:1234",
+                                    didDocumentKeys: [key],
+                                    updateKey: key,
+                                    recoveryKey: key,
+                                    alias: "mock alias")
+        return identifier
+    }
+}
+

--- a/WalletLibrary/WalletLibraryTests/Mocks/MockVerifiableCredentialHelper.swift
+++ b/WalletLibrary/WalletLibraryTests/Mocks/MockVerifiableCredentialHelper.swift
@@ -19,11 +19,13 @@ struct MockVerifiableCredentialHelper {
     
     func createVCEntitiesVC(expectedTypes: [String],
                             claims: [String:String],
-                            issuer: String) -> VerifiableCredential {
-        let claims = VCClaims(jti: "",
+                            issuer: String,
+                            jti: String? = "",
+                            iat: Double? = 0) -> VerifiableCredential {
+        let claims = VCClaims(jti: jti,
                               iss: issuer,
                               sub: "",
-                              iat: 0,
+                              iat: iat,
                               exp: 0,
                               vc: VerifiableCredentialDescriptor(context: [],
                                                                  type: expectedTypes,

--- a/WalletLibrary/WalletLibraryTests/Networking/Formatters/RawOpenID4VCIRequestFormatterTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Networking/Formatters/RawOpenID4VCIRequestFormatterTests.swift
@@ -100,10 +100,10 @@ class RawOpenID4VCIRequestFormatterTests: XCTestCase
         XCTAssertEqual(request.credential_configuration_id, mockConfigurationId)
         XCTAssertEqual(request.issuer_session, mockIssuerSession)
         XCTAssertEqual(request.proof.proof_type, "jwt")
-        let result = JwsToken<OpenID4VCIJWTProofClaims>(from: request.proof.jwt)
-        XCTAssertEqual(result?.content.aud, mockEndpoint)
-        XCTAssertEqual(result?.content.sub, "did:test:1234")
-        XCTAssertEqual(result?.content.at_hash, "1EZBnvsFWlK8ESkgHQsrISKuTFVEzRM4MyM9Z7xwrDs")
+        let proof = JwsToken<OpenID4VCIJWTProofClaims>(from: request.proof.jwt)
+        XCTAssertEqual(proof?.content.aud, mockEndpoint)
+        XCTAssertEqual(proof?.content.sub, "did:test:1234")
+        XCTAssertEqual(proof?.content.at_hash, "1EZBnvsFWlK8ESkgHQsrISKuTFVEzRM4MyM9Z7xwrDs")
     }
     
     private func createCredentialOffer(configIds: [String] = ["configIds"],

--- a/WalletLibrary/WalletLibraryTests/Networking/Formatters/RawOpenID4VCIRequestFormatterTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Networking/Formatters/RawOpenID4VCIRequestFormatterTests.swift
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import XCTest
+@testable import WalletLibrary
+
+class RawOpenID4VCIRequestFormatterTests: XCTestCase
+{
+    
+    func testFormat_WithInvalidConfigIds_ThrowsError() async throws
+    {
+        // Arrange
+        let formatter = RawOpenID4VCIRequestFormatter(signer: MockSigner(),
+                                                      configuration: LibraryConfiguration())
+        let mockAccessToken = "mock access token"
+        let mockEndpoint = "mock endpoint"
+        let mockCredentialOffer = createCredentialOffer(configIds: [])
+        
+        // Act / Assert
+        XCTAssertThrowsError(try formatter.format(credentialOffer: mockCredentialOffer,
+                                                  credentialEndpoint: mockEndpoint,
+                                                  accessToken: mockAccessToken)) { error in
+            XCTAssert(error is OpenId4VCIValidationError)
+            let validationError = error as! OpenId4VCIValidationError
+            XCTAssertEqual(validationError.code, "request_creation_error")
+            XCTAssertEqual(validationError.message, "Configuration Id not present in Credential Offer.")
+        }
+    }
+    
+    func testFormat_WhenUnableToFetchIdentifier_ThrowsError() async throws
+    {
+        // Arrange
+        let mockIdentifierManager = MockIdentifierManager(doesThrow: true)
+        let libraryConfig = LibraryConfiguration(identifierManager: mockIdentifierManager)
+        let formatter = RawOpenID4VCIRequestFormatter(signer: MockSigner(),
+                                                      configuration: libraryConfig)
+        let mockAccessToken = "mock access token"
+        let mockEndpoint = "mock endpoint"
+        let mockCredentialOffer = createCredentialOffer()
+        
+        // Act / Assert
+        XCTAssertThrowsError(try formatter.format(credentialOffer: mockCredentialOffer,
+                                                  credentialEndpoint: mockEndpoint,
+                                                  accessToken: mockAccessToken)) { error in
+            XCTAssert(error is OpenId4VCIValidationError)
+            let validationError = error as! OpenId4VCIValidationError
+            XCTAssertEqual(validationError.code, "request_creation_error")
+            XCTAssertEqual(validationError.message, "Unable to fetch user's signing key reference.")
+        }
+    }
+    
+    func testFormat_WhenSigningThrowsError_ThrowsError() async throws
+    {
+        // Arrange
+        let mockSigner = MockSigner(doesSignThrow: true)
+        let mockIdentifierManager = MockIdentifierManager()
+        let libraryConfig = LibraryConfiguration(identifierManager: mockIdentifierManager)
+        let formatter = RawOpenID4VCIRequestFormatter(signer: mockSigner,
+                                                      configuration: libraryConfig)
+        let mockAccessToken = "mock access token"
+        let mockEndpoint = "mock endpoint"
+        let mockCredentialOffer = createCredentialOffer()
+        
+        // Act / Assert
+        XCTAssertThrowsError(try formatter.format(credentialOffer: mockCredentialOffer,
+                                                  credentialEndpoint: mockEndpoint,
+                                                  accessToken: mockAccessToken)) { error in
+            XCTAssert(error is OpenId4VCIValidationError)
+            let validationError = error as! OpenId4VCIValidationError
+            XCTAssertEqual(validationError.code, "request_creation_error")
+            XCTAssertEqual(validationError.message, "Unable to format the Proof Token.")
+            XCTAssertEqual(validationError.error as? MockSigner.ExpectedError,
+                           MockSigner.ExpectedError.SignExpectedToThrow)
+        }
+    }
+    
+    func testFormat_WhenWithValidInput_ReturnsRequest() async throws
+    {
+        // Arrange
+        let mockSigner = MockSigner()
+        let mockIdentifierManager = MockIdentifierManager()
+        let libraryConfig = LibraryConfiguration(identifierManager: mockIdentifierManager)
+        let formatter = RawOpenID4VCIRequestFormatter(signer: mockSigner,
+                                                      configuration: libraryConfig)
+        let mockAccessToken = "mock access token"
+        let mockEndpoint = "mock endpoint"
+        let mockConfigurationId = "mock config id"
+        let mockIssuerSession = "mock issuer session"
+        let mockCredentialOffer = createCredentialOffer(configIds: [mockConfigurationId],
+                                                        issuerSession: mockIssuerSession)
+        
+        // Act
+        let request = try formatter.format(credentialOffer: mockCredentialOffer,
+                                           credentialEndpoint: mockEndpoint,
+                                           accessToken: mockAccessToken)
+        
+        // Assert
+        XCTAssertEqual(request.credential_configuration_id, mockConfigurationId)
+        XCTAssertEqual(request.issuer_session, mockIssuerSession)
+        XCTAssertEqual(request.proof.proof_type, "jwt")
+        let result = JwsToken<OpenID4VCIJWTProofClaims>(from: request.proof.jwt)
+        XCTAssertEqual(result?.content.aud, mockEndpoint)
+        XCTAssertEqual(result?.content.sub, "did:test:1234")
+        XCTAssertEqual(result?.content.at_hash, "1EZBnvsFWlK8ESkgHQsrISKuTFVEzRM4MyM9Z7xwrDs")
+    }
+    
+    private func createCredentialOffer(configIds: [String] = ["configIds"],
+                                       issuerSession: String = "") -> CredentialOffer
+    {
+        return CredentialOffer(credential_issuer: "",
+                               issuer_session: issuerSession,
+                               credential_configuration_ids: configIds,
+                               grants: [:])
+    }
+}

--- a/WalletLibrary/WalletLibraryTests/VerifiedId/OpenID4VCIVerifiedIDTests.swift
+++ b/WalletLibrary/WalletLibraryTests/VerifiedId/OpenID4VCIVerifiedIDTests.swift
@@ -1,0 +1,182 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import XCTest
+@testable import WalletLibrary
+
+class OpenID4VCIVerifiedIDTests: XCTestCase
+{
+    struct MockVerifiableCredential: Codable 
+    {
+        let vc: String
+        
+        let configuration: CredentialConfiguration
+        
+        let issuerName: String
+    }
+    
+    func testInit_WithInvalidRawToken_ThrowsError() async throws
+    {
+        // Arrange
+        let mockRaw = "mock raw"
+        let mockIssuerName = "mock issuer name"
+        let mockConfig = createCredentialConfiguration()
+        
+        // Act / Assert
+        XCTAssertThrowsError(try OpenID4VCIVerifiedId(raw: mockRaw,
+                                                      issuerName: mockIssuerName,
+                                                      configuration: mockConfig)) { error in
+            XCTAssert(error is MappingError)
+            XCTAssertEqual(error as? MappingError, .InvalidProperty(property: "rawToken", in: "raw"))
+        }
+    }
+    
+    func testInit_WithNilIat_ThrowsError() async throws
+    {
+        // Arrange
+        let mockVC = MockVerifiableCredentialHelper().createVCEntitiesVC(expectedTypes: [],
+                                                                         claims: [:],
+                                                                         issuer: "",
+                                                                         iat: nil)
+        let rawVC = try mockVC.serialize()
+        let mockIssuerName = "mock issuer name"
+        let mockConfig = createCredentialConfiguration()
+        
+        // Act / Assert
+        XCTAssertThrowsError(try OpenID4VCIVerifiedId(raw: rawVC,
+                                                      issuerName: mockIssuerName,
+                                                      configuration: mockConfig)) { error in
+            XCTAssert(error is MappingError)
+            XCTAssertEqual(error as? MappingError, .PropertyNotPresent(property: "iat", in: "VCClaims"))
+        }
+    }
+    
+    func testInit_WithNilJTI_ThrowsError() async throws
+    {
+        // Arrange
+        let mockVC = MockVerifiableCredentialHelper().createVCEntitiesVC(expectedTypes: [],
+                                                                         claims: [:],
+                                                                         issuer: "",
+                                                                         jti: nil)
+        let rawVC = try mockVC.serialize()
+        let mockIssuerName = "mock issuer name"
+        let mockConfig = createCredentialConfiguration()
+        
+        // Act / Assert
+        XCTAssertThrowsError(try OpenID4VCIVerifiedId(raw: rawVC,
+                                                      issuerName: mockIssuerName,
+                                                      configuration: mockConfig)) { error in
+            XCTAssert(error is MappingError)
+            XCTAssertEqual(error as? MappingError, .PropertyNotPresent(property: "jti", in: "VCClaims"))
+        }
+    }
+    
+    func testInit_WithValidInputs_ReturnsVerifiedID() async throws
+    {
+        // Arrange
+        let mockIssuerDID = "mock issuer DID"
+        let mockTypes = ["mockType1", "mockType2"]
+        let mockID = "mock ID"
+        let mockVC = MockVerifiableCredentialHelper().createVCEntitiesVC(expectedTypes: mockTypes,
+                                                                         claims: [:],
+                                                                         issuer: mockIssuerDID,
+                                                                         jti: mockID)
+        let rawVC = try mockVC.serialize()
+        let mockIssuerName = "mock issuer name"
+        let mockConfig = createCredentialConfiguration()
+        
+        // Act
+        let result = try OpenID4VCIVerifiedId(raw: rawVC,
+                                              issuerName: mockIssuerName,
+                                              configuration: mockConfig)
+        
+        // Assert
+        XCTAssertEqual(try result.vc.serialize(), rawVC)
+        XCTAssertEqual(result.id, mockID)
+        XCTAssertEqual(result.issuerName, mockIssuerName)
+        XCTAssertEqual(result.types, mockTypes)
+        XCTAssertEqual(result.expiresOn, Date(timeIntervalSince1970: 0))
+        XCTAssertEqual(result.issuedOn, Date(timeIntervalSince1970: 0))
+        XCTAssert(result.style is BasicVerifiedIdStyle)
+    }
+    
+    func testEncode_WithValidInputs_EncodesVCProperly() async throws
+    {
+        // Arrange
+        let mockIssuerDID = "mock issuer DID"
+        let mockTypes = ["mockType1", "mockType2"]
+        let mockID = "mock ID"
+        let mockVC = MockVerifiableCredentialHelper().createVCEntitiesVC(expectedTypes: mockTypes,
+                                                                         claims: [:],
+                                                                         issuer: mockIssuerDID,
+                                                                         jti: mockID)
+        let rawVC = try mockVC.serialize()
+        let mockIssuerName = "mock issuer name"
+        let mockConfig = createCredentialConfiguration()
+        
+        let vc = try OpenID4VCIVerifiedId(raw: rawVC,
+                                          issuerName: mockIssuerName,
+                                          configuration: mockConfig)
+        
+        let mockEncoded = MockVerifiableCredential(vc: rawVC,
+                                                   configuration: mockConfig,
+                                                   issuerName: mockIssuerName)
+        let expected = try JSONEncoder().encode(mockEncoded)
+        
+        // Act
+        let result = try JSONEncoder().encode(vc)
+        
+        // Assert
+        XCTAssertEqual(result, expected)
+    }
+    
+    func testDecode_WithValidInputs_EncodesVCProperly() async throws
+    {
+        // Arrange
+        let mockIssuerDID = "mock issuer DID"
+        let mockTypes = ["mockType1", "mockType2"]
+        let mockID = "mock ID"
+        let mockVC = MockVerifiableCredentialHelper().createVCEntitiesVC(expectedTypes: mockTypes,
+                                                                         claims: [:],
+                                                                         issuer: mockIssuerDID,
+                                                                         jti: mockID)
+        let rawVC = try mockVC.serialize()
+        let mockIssuerName = "mock issuer name"
+        let mockConfig = createCredentialConfiguration()
+        
+        let vc = try OpenID4VCIVerifiedId(raw: rawVC,
+                                          issuerName: mockIssuerName,
+                                          configuration: mockConfig)
+        
+        let mockEncoded = MockVerifiableCredential(vc: rawVC,
+                                                   configuration: mockConfig,
+                                                   issuerName: mockIssuerName)
+        let encodedVC = try JSONEncoder().encode(mockEncoded)
+        
+        // Act
+        let result = try JSONDecoder().decode(OpenID4VCIVerifiedId.self, from: encodedVC)
+        
+        // Assert
+        XCTAssertEqual(try result.vc.serialize(), rawVC)
+        XCTAssertEqual(result.id, mockID)
+        XCTAssertEqual(result.issuerName, mockIssuerName)
+        XCTAssertEqual(result.types, mockTypes)
+        XCTAssertEqual(result.expiresOn, Date(timeIntervalSince1970: 0))
+        XCTAssertEqual(result.issuedOn, Date(timeIntervalSince1970: 0))
+        XCTAssert(result.style is BasicVerifiedIdStyle)
+    }
+    
+    private func createCredentialConfiguration() -> CredentialConfiguration
+    {
+        let config = CredentialConfiguration(format: nil,
+                                             scope: nil,
+                                             cryptographic_binding_methods_supported: nil,
+                                             cryptographic_suites_supported: nil,
+                                             credential_definition: nil,
+                                             display: nil,
+                                             proof_types_supported: nil)
+        return config
+    }
+}


### PR DESCRIPTION
**Problem:**
More unit tests should be added for `RawOpenID4VCIRequestFormatter` and `OpenID4VCIVerifiedID` internal classes.


**Solution:**
Add unit tests.


**Validation:**
They all pass.


**Type of change:**
- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [X] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.