### PR TITLE
Support Verifiable Credential Serializer.

### DIFF
--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -465,6 +465,8 @@
 		55A4BB332A29383A006836AB /* VerifiedIdResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A4BB322A29383A006836AB /* VerifiedIdResult.swift */; };
 		55A4BB3F2A2A5576006836AB /* VerifiedIdErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A4BB3E2A2A5576006836AB /* VerifiedIdErrors.swift */; };
 		55A6384B2BB1E0D600BE2AF2 /* MockRequestProcessorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A6384A2BB1E0D600BE2AF2 /* MockRequestProcessorExtension.swift */; };
+		55A638852BB5BFAA00BE2AF2 /* VerifiableCredentialSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A638842BB5BFAA00BE2AF2 /* VerifiableCredentialSerializer.swift */; };
+		55A638882BB5BFE400BE2AF2 /* VerifiableCredentialSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A638872BB5BFE400BE2AF2 /* VerifiableCredentialSerializerTests.swift */; };
 		55A81BCA2991AB82002C259A /* RequestResolving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A81BC92991AB82002C259A /* RequestResolving.swift */; };
 		55A81BE12991AB96002C259A /* RequestProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A81BE02991AB96002C259A /* RequestProcessing.swift */; };
 		55A81BE52991B2E5002C259A /* RequestResolverFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A81BE42991B2E5002C259A /* RequestResolverFactory.swift */; };
@@ -1029,6 +1031,8 @@
 		55A4BB322A29383A006836AB /* VerifiedIdResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedIdResult.swift; sourceTree = "<group>"; };
 		55A4BB3E2A2A5576006836AB /* VerifiedIdErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedIdErrors.swift; sourceTree = "<group>"; };
 		55A6384A2BB1E0D600BE2AF2 /* MockRequestProcessorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRequestProcessorExtension.swift; sourceTree = "<group>"; };
+		55A638842BB5BFAA00BE2AF2 /* VerifiableCredentialSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiableCredentialSerializer.swift; sourceTree = "<group>"; };
+		55A638872BB5BFE400BE2AF2 /* VerifiableCredentialSerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiableCredentialSerializerTests.swift; sourceTree = "<group>"; };
 		55A81BC92991AB82002C259A /* RequestResolving.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestResolving.swift; sourceTree = "<group>"; };
 		55A81BE02991AB96002C259A /* RequestProcessing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestProcessing.swift; sourceTree = "<group>"; };
 		55A81BE42991B2E5002C259A /* RequestResolverFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestResolverFactory.swift; sourceTree = "<group>"; };
@@ -1445,6 +1449,7 @@
 		553CC09E29A97FD7005A5FD6 /* VerifiedId */ = {
 			isa = PBXGroup;
 			children = (
+				55A638862BB5BFCD00BE2AF2 /* Serializers */,
 				558CF1AC2B869CDD00AF5D82 /* OpenID4VCIVerifiedIDTests.swift */,
 				553CC09F29A98003005A5FD6 /* VCVerifiedIdTests.swift */,
 				55BA2DD829CDFA6100BB8207 /* VerifiedIdDecoderTests.swift */,
@@ -2710,6 +2715,22 @@
 			path = ProcessorExtensions;
 			sourceTree = "<group>";
 		};
+		55A638832BB5BF9800BE2AF2 /* Serializers */ = {
+			isa = PBXGroup;
+			children = (
+				55A638842BB5BFAA00BE2AF2 /* VerifiableCredentialSerializer.swift */,
+			);
+			path = Serializers;
+			sourceTree = "<group>";
+		};
+		55A638862BB5BFCD00BE2AF2 /* Serializers */ = {
+			isa = PBXGroup;
+			children = (
+				55A638872BB5BFE400BE2AF2 /* VerifiableCredentialSerializerTests.swift */,
+			);
+			path = Serializers;
+			sourceTree = "<group>";
+		};
 		55A81BF02991BB13002C259A /* Requests */ = {
 			isa = PBXGroup;
 			children = (
@@ -2899,6 +2920,7 @@
 		55E336D2293FA74100CD2ED7 /* VerifiedId */ = {
 			isa = PBXGroup;
 			children = (
+				55A638832BB5BF9800BE2AF2 /* Serializers */,
 				559BD4B1299EDF9E00BD61AC /* VerifiableCredential */,
 				55BA2DD029CDFA1A00BB8207 /* EncodedVerifiedId.swift */,
 				55E336D3293FA75300CD2ED7 /* VerifiedId.swift */,
@@ -3553,6 +3575,7 @@
 				5552D44829EF4A8100B40302 /* NetworkOperation.swift in Sources */,
 				5524A60C29D634BC00C5F18D /* VerifiedIdLogo.swift in Sources */,
 				55A81BCA2991AB82002C259A /* RequestResolving.swift in Sources */,
+				55A638852BB5BFAA00BE2AF2 /* VerifiableCredentialSerializer.swift in Sources */,
 				5552D3C429EF489E00B40302 /* IONDocumentModel.swift in Sources */,
 				5552D48529EF4AAB00B40302 /* JWK.swift in Sources */,
 				A4B4FA622B924E5C00F0AAF3 /* InternalExtensionIdentifierManager.swift in Sources */,
@@ -3599,6 +3622,7 @@
 				559BD455299D3E4800BD61AC /* IssuanceRequest+MappableTests.swift in Sources */,
 				553CC0A029A98003005A5FD6 /* VCVerifiedIdTests.swift in Sources */,
 				55A81C132991C829002C259A /* MockHandler.swift in Sources */,
+				55A638882BB5BFE400BE2AF2 /* VerifiableCredentialSerializerTests.swift in Sources */,
 				559BD3072995ABD300BD61AC /* PresentationInputDescriptor+MappableTests.swift in Sources */,
 				5552D81A29F2E25900B40302 /* TestData.swift in Sources */,
 				558328582B97A866000CEC89 /* FormURLEncodedRequestEncoderTests.swift in Sources */,

--- a/WalletLibrary/WalletLibrary/Errors/VerifiedIdError.swift
+++ b/WalletLibrary/WalletLibrary/Errors/VerifiedIdError.swift
@@ -4,13 +4,15 @@
 *--------------------------------------------------------------------------------------------*/
 
 /// Base Error Protocol. Every error that is returned from the library is a VerifiedIdError.
-public class VerifiedIdError: LocalizedError, CustomStringConvertible, Encodable {
-
+/// This class is open to enable Extensions to create VerifiedIdErrors.
+open class VerifiedIdError: LocalizedError, CustomStringConvertible, Encodable
+{
     public let message: String
     public let code: String
     public let correlationId: String?
     
-    init(message: String, code: String, correlationId: String? = nil) {
+    init(message: String, code: String, correlationId: String? = nil) 
+    {
         self.message = message
         self.code = code
         self.correlationId = correlationId
@@ -18,7 +20,8 @@ public class VerifiedIdError: LocalizedError, CustomStringConvertible, Encodable
     
     public var description: String {
         if let encodedObject = try? JSONEncoder().encode(self),
-           let description = String(data: encodedObject, encoding: .utf8) {
+           let description = String(data: encodedObject, encoding: .utf8) 
+        {
             return description
         }
         
@@ -34,7 +37,8 @@ public class VerifiedIdError: LocalizedError, CustomStringConvertible, Encodable
     }
     
     /// Helper function to wrap error in a VerifiedIdResult.
-    func result<T>() -> VerifiedIdResult<T> {
+    func result<T>() -> VerifiedIdResult<T> 
+    {
         return VerifiedIdResult(error: self)
     }
 }

--- a/WalletLibrary/WalletLibrary/Extensions/Services/IssuanceService+VerifiableCredentialRequester.swift
+++ b/WalletLibrary/WalletLibrary/Extensions/Services/IssuanceService+VerifiableCredentialRequester.swift
@@ -18,7 +18,7 @@ extension IssuanceService: VerifiedIdRequester {
     func send<Request>(request: Request) async throws -> VerifiedId {
         
         guard let issuanceResponseContainer = request as? IssuanceResponseContainer else {
-            let requestType = String(describing: request.self)
+            let requestType = String(describing: type(of: request.self))
             throw IssuanceServiceVCRequesterError.unableToCastIssuanceResponseContainerFromType(requestType)
         }
         
@@ -32,7 +32,7 @@ extension IssuanceService: VerifiedIdRequester {
     func send<IssuanceResult>(result: IssuanceResult, to url: URL) async throws -> Void {
         
         guard let issuanceCompletionResponse = result as? IssuanceCompletionResponse else {
-            let resultType = String(describing: result.self)
+            let resultType = String(describing: type(of: result.self))
             throw IssuanceServiceVCRequesterError.unableToCastIssuanceCompletionResponseFromType(resultType)
         }
         

--- a/WalletLibrary/WalletLibrary/VerifiedId/Serializers/VerifiableCredentialSerializer.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedId/Serializers/VerifiableCredentialSerializer.swift
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+/**
+ * Serializes a Verifiable Credential.
+ * Input `VerifiedId` must conform to the `InternalVerifiedId` protocol
+ * in order to access the `VerifiableCredential` property that can be serialized into the
+ * compact token format.
+ */
+struct VerifiableCredentialSerializer: VerifiedIdSerializing
+{
+    func serialize(verifiedId: VerifiedId) throws -> String
+    {
+        guard let vc = verifiedId as? InternalVerifiedId else
+        {
+            let message = "Unsupported Verified ID Type during serialization: \(String(describing: type(of: verifiedId)))."
+            throw VerifiedIdErrors.MalformedInput(message: message).error
+        }
+        
+        return try vc.raw.serialize()
+    }
+}

--- a/WalletLibrary/WalletLibraryTests/VerifiedId/OpenID4VCIVerifiedIDTests.swift
+++ b/WalletLibrary/WalletLibraryTests/VerifiedId/OpenID4VCIVerifiedIDTests.swift
@@ -146,10 +146,6 @@ class OpenID4VCIVerifiedIDTests: XCTestCase
         let mockIssuerName = "mock issuer name"
         let mockConfig = createCredentialConfiguration()
         
-        let vc = try OpenID4VCIVerifiedId(raw: rawVC,
-                                          issuerName: mockIssuerName,
-                                          configuration: mockConfig)
-        
         let mockEncoded = MockVerifiableCredential(vc: rawVC,
                                                    configuration: mockConfig,
                                                    issuerName: mockIssuerName)

--- a/WalletLibrary/WalletLibraryTests/VerifiedId/Serializers/VerifiableCredentialSerializerTests.swift
+++ b/WalletLibrary/WalletLibraryTests/VerifiedId/Serializers/VerifiableCredentialSerializerTests.swift
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import XCTest
+@testable import WalletLibrary
+
+class VerifiableCredentialSerializerTests: XCTestCase
+{
+    func testSerialize_WithInvalidType_ThrowsError() async throws
+    {
+        // Arrange
+        let mockVerifiedId = MockVerifiedId(id: "mockId", issuedOn: Date())
+        let serializer = VerifiableCredentialSerializer()
+        
+        // Act / Assert
+        XCTAssertThrowsError(try serializer.serialize(verifiedId: mockVerifiedId)) { error in
+            XCTAssert(error is MalformedInputError)
+            XCTAssertEqual((error as? MalformedInputError)?.code, "malformed_input_error")
+            XCTAssertEqual((error as? MalformedInputError)?.message, "Unsupported Verified ID Type during serialization: MockVerifiedId.")
+        }
+    }
+    
+    func testSerialize_WithValidType_ReturnsSerializedVC() async throws
+    {
+        // Arrange
+        let mockVerifiedId = MockVerifiableCredentialHelper().createMockVerifiableCredential()
+        let serializer = VerifiableCredentialSerializer()
+        
+        // Act
+        let result = try serializer.serialize(verifiedId: mockVerifiedId)
+        
+        // Assert
+        XCTAssertEqual(result, try mockVerifiedId.raw.serialize())
+    }
+}


### PR DESCRIPTION
**Problem:**
1. Library needs to support concrete implementation of `VerifiedIdSerializing` to enable Extensions.
2. Extensions need `VerifiedIdError` to be open to create their own errors.

**Solution:**
1. Implement `VerifiableCredentialSerializer`.
2. Make `VerifiedIdError` open.
3. Fix some small logging bug.

**Validation:**
All Unit tests pass.

**Type of change:**
- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.