### PR TITLE
Add replaceRequirement helper method to PartialRequest.

### DIFF
--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		555FB2422B7BC97A00EE14BD /* CredentialMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB2412B7BC97A00EE14BD /* CredentialMetadataTests.swift */; };
 		555FB2442B7BCE4500EE14BD /* SignedCredentialMetadataProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB2432B7BCE4500EE14BD /* SignedCredentialMetadataProcessing.swift */; };
 		555FB2462B7BD20100EE14BD /* MockSignedMetadataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB2452B7BD20100EE14BD /* MockSignedMetadataProcessor.swift */; };
+		5575393B2BBC91E2009E1257 /* VerifiedIdPartialRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5575393A2BBC91E2009E1257 /* VerifiedIdPartialRequestTests.swift */; };
 		558168E02BA8B5EE000E9CA5 /* SignedCredentialMetadataProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558168DB2BA8B5EE000E9CA5 /* SignedCredentialMetadataProcessing.swift */; };
 		558168E12BA8B5EE000E9CA5 /* RequestProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558168DC2BA8B5EE000E9CA5 /* RequestProcessing.swift */; };
 		558168E22BA8B5EE000E9CA5 /* RequestProcessorSerializing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558168DD2BA8B5EE000E9CA5 /* RequestProcessorSerializing.swift */; };
@@ -968,6 +969,7 @@
 		555FB2412B7BC97A00EE14BD /* CredentialMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialMetadataTests.swift; sourceTree = "<group>"; };
 		555FB2432B7BCE4500EE14BD /* SignedCredentialMetadataProcessing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedCredentialMetadataProcessing.swift; sourceTree = "<group>"; };
 		555FB2452B7BD20100EE14BD /* MockSignedMetadataProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSignedMetadataProcessor.swift; sourceTree = "<group>"; };
+		5575393A2BBC91E2009E1257 /* VerifiedIdPartialRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedIdPartialRequestTests.swift; sourceTree = "<group>"; };
 		558168DB2BA8B5EE000E9CA5 /* SignedCredentialMetadataProcessing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignedCredentialMetadataProcessing.swift; sourceTree = "<group>"; };
 		558168DC2BA8B5EE000E9CA5 /* RequestProcessing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestProcessing.swift; sourceTree = "<group>"; };
 		558168DD2BA8B5EE000E9CA5 /* RequestProcessorSerializing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestProcessorSerializing.swift; sourceTree = "<group>"; };
@@ -2722,6 +2724,7 @@
 				55A81C062991BB2C002C259A /* RequestResolverFactoryTests.swift */,
 				55A81C082991BB3A002C259A /* RequestProcessorFactoryTests.swift */,
 				55DECBEE29BA2BEE00D5C802 /* IssuanceRequestContentTests.swift */,
+				5575393A2BBC91E2009E1257 /* VerifiedIdPartialRequestTests.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -3650,6 +3653,7 @@
 				5552D82C29F2E25900B40302 /* PresentationRequestValidatorTests.swift in Sources */,
 				553CC09929A96C38005A5FD6 /* MockVerifiedId.swift in Sources */,
 				5552D82D29F2E25900B40302 /* OIDCClaimsTests.swift in Sources */,
+				5575393B2BBC91E2009E1257 /* VerifiedIdPartialRequestTests.swift in Sources */,
 				555FB20F2B75874A00EE14BD /* SignedCredentialMetadataProcessorTests.swift in Sources */,
 				55DECC4129BFEDE400D5C802 /* VerifiedIdRequirementTests.swift in Sources */,
 				5552D7D729F2E0AA00B40302 /* Secp256k1Tests.swift in Sources */,

--- a/WalletLibrary/WalletLibrary/Requests/VerifiedIdPartialRequest.swift
+++ b/WalletLibrary/WalletLibrary/Requests/VerifiedIdPartialRequest.swift
@@ -38,4 +38,61 @@ public class VerifiedIdPartialRequest
         self.requirement = requirement
         self.rootOfTrust = rootOfTrust
     }
+    
+    /**
+     * Replace `VerifiedIdRequirement` with given id in `Requirement` tree on the `VerifiedIdPartialRequest` using the
+     * given transformer.
+     * - Returns:
+     *   - Requirement: the updated requirement or nil if not requirement was replaced.
+     */
+    public func replaceRequirement(id: String, how transformer: (VerifiedIdRequirement) -> Requirement) -> Requirement?
+    {
+        let (updatedRequirementTree, updatedRequirement) = replaceRequirement(id: id, from: requirement, transformer)
+        requirement = updatedRequirementTree
+        return updatedRequirement
+    }
+    
+    /// Recurse through the requirements and if there is a VerifiedIdRequirement with given id,
+    /// replace requirement using given transformer and return replaced requirement. Return nil if not requirement
+    /// matching those constraints was found.
+    private func replaceRequirement(id: String,
+                                    from oldRequirement: Requirement,
+                                    _ transformer: (VerifiedIdRequirement) -> Requirement) -> (Requirement, Requirement?)
+    {
+        switch oldRequirement
+        {
+        case let groupRequirement as GroupRequirement:
+            for (index, childRequirement) in groupRequirement.requirements.enumerated()
+            {
+                let (updatedReqTree, updatedReq) = replaceRequirement(id: id, from: childRequirement, transformer)
+                if let updatedReq = updatedReq
+                {
+                    groupRequirement.requirements[index] = updatedReqTree
+                    return (groupRequirement, updatedReq)
+                }
+            }
+            
+            return (oldRequirement, nil)
+            
+        case let verifiedIdRequirement as VerifiedIdRequirement:
+            return replaceRequirement(id: id, from: verifiedIdRequirement, transformer)
+        default:
+            return (oldRequirement, nil)
+        }
+    }
+    
+    private func replaceRequirement(id: String,
+                                    from oldRequirement: VerifiedIdRequirement,
+                                    _ transformer: (VerifiedIdRequirement) -> Requirement) -> (Requirement, Requirement?)
+    {
+        if oldRequirement.id == id
+        {
+            let updatedRequirement = transformer(oldRequirement)
+            return (updatedRequirement, updatedRequirement)
+        }
+        else
+        {
+            return (oldRequirement, nil)
+        }
+    }
 }

--- a/WalletLibrary/WalletLibraryTests/Requests/VerifiedIdPartialRequestTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Requests/VerifiedIdPartialRequestTests.swift
@@ -1,0 +1,211 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import XCTest
+@testable import WalletLibrary
+
+class VerifiedIdPartialRequestTests: XCTestCase
+{
+    func testReplaceRequirement_WithRequirementNotMatching_ReturnsNil() async throws
+    {
+        var wasCalled = false
+        
+        let mockTransformer: ((VerifiedIdRequirement) -> Requirement) = { req in
+            wasCalled = true
+            return MockRequirement(id: "wrongId23")
+        }
+        
+        // Arrange
+        let mockReq = MockRequirement(id: "notMatchingId")
+        let partialRequest = VerifiedIdPartialRequest(requesterStyle: MockRequesterStyle(requester: ""),
+                                                      requirement: mockReq,
+                                                      rootOfTrust: RootOfTrust(verified: false, source: nil))
+        
+        // Act / Assert
+        XCTAssertNil(partialRequest.replaceRequirement(id: "mockId", how: mockTransformer))
+        XCTAssertFalse(wasCalled)
+    }
+    
+    func testReplaceRequirement_WithRequirementMatching_ReturnsUpdatedRequirement() async throws
+    {
+        let id = "expectedId"
+        var wasCalled = false
+        let expectedRequirement = VerifiedIdRequirement(encrypted: false,
+                                                        required: true,
+                                                        types: [],
+                                                        purpose: nil,
+                                                        issuanceOptions: [],
+                                                        id: id,
+                                                        constraint: MockConstraint(doesMatchResult: true))
+        
+        let expectedResult = MockRequirement(id: id)
+        
+        let mockTransformer: ((VerifiedIdRequirement) -> Requirement) = { req in
+            wasCalled = true
+            return expectedResult
+        }
+        
+        // Arrange
+        let partialRequest = VerifiedIdPartialRequest(requesterStyle: MockRequesterStyle(requester: ""),
+                                                      requirement: expectedRequirement,
+                                                      rootOfTrust: RootOfTrust(verified: false, source: nil))
+        
+        // Act
+        let result = partialRequest.replaceRequirement(id: id, how: mockTransformer)
+        
+        // Assert
+        XCTAssert(wasCalled)
+        XCTAssertEqual(partialRequest.requirement as? MockRequirement, expectedResult)
+        print(partialRequest.requirement)
+        XCTAssertEqual(result as? MockRequirement, expectedResult)
+    }
+    
+    func testReplaceRequirement_WithGroupRequirement_ReturnsUpdatedRequirement() async throws
+    {
+        let id = "expectedId"
+        var wasCalled = false
+        let expectedRequirement = VerifiedIdRequirement(encrypted: false,
+                                                        required: true,
+                                                        types: [],
+                                                        purpose: nil,
+                                                        issuanceOptions: [],
+                                                        id: id,
+                                                        constraint: MockConstraint(doesMatchResult: true))
+        let mockRequirement1 = MockRequirement(id: "wrongId")
+        let mockRequirement2 = MockRequirement(id: "wrongId2")
+        
+        let expectedResult = MockRequirement(id: id)
+        
+        let groupRequirement = GroupRequirement(required: true,
+                                                requirements: [expectedRequirement, 
+                                                               mockRequirement1,
+                                                               mockRequirement2],
+                                                requirementOperator: .ALL)
+        
+        let mockTransformer: ((VerifiedIdRequirement) -> Requirement) = { req in
+            wasCalled = true
+            return expectedResult
+        }
+        
+        // Arrange
+        let partialRequest = VerifiedIdPartialRequest(requesterStyle: MockRequesterStyle(requester: ""),
+                                                      requirement: groupRequirement,
+                                                      rootOfTrust: RootOfTrust(verified: false, source: nil))
+        
+        // Act
+        let result = partialRequest.replaceRequirement(id: id, how: mockTransformer)
+        
+        // Assert
+        XCTAssert(wasCalled)
+        XCTAssertEqual((partialRequest.requirement as? GroupRequirement)?.requirements.count, 3)
+        XCTAssertEqual((partialRequest.requirement as? GroupRequirement)?.requirements[0] as? MockRequirement,
+                       expectedResult)
+        XCTAssertEqual((partialRequest.requirement as? GroupRequirement)?.requirements[1] as? MockRequirement,
+                       mockRequirement1)
+        XCTAssertEqual((partialRequest.requirement as? GroupRequirement)?.requirements[2] as? MockRequirement,
+                       mockRequirement2)
+        XCTAssertEqual(result as? MockRequirement, expectedResult)
+    }
+    
+    func testReplaceRequirement_WithGroupRequirementAndNoMatches_ReturnsNil() async throws
+    {
+        let id = "expectedId"
+        var wasCalled = false
+        let verifiedIdRequirement = VerifiedIdRequirement(encrypted: false,
+                                                        required: true,
+                                                        types: [],
+                                                        purpose: nil,
+                                                        issuanceOptions: [],
+                                                        id: "wrongIdForVerifiedIdRequirement",
+                                                        constraint: MockConstraint(doesMatchResult: true))
+        let mockRequirement1 = MockRequirement(id: "wrongId")
+        let mockRequirement2 = MockRequirement(id: "wrongId2")
+        
+        let expectedResult = MockRequirement(id: id)
+        
+        let groupRequirement = GroupRequirement(required: true,
+                                                requirements: [verifiedIdRequirement,
+                                                               mockRequirement1,
+                                                               mockRequirement2],
+                                                requirementOperator: .ALL)
+        
+        let mockTransformer: ((VerifiedIdRequirement) -> Requirement) = { req in
+            wasCalled = true
+            return expectedResult
+        }
+        
+        // Arrange
+        let partialRequest = VerifiedIdPartialRequest(requesterStyle: MockRequesterStyle(requester: ""),
+                                                      requirement: groupRequirement,
+                                                      rootOfTrust: RootOfTrust(verified: false, source: nil))
+        
+        // Act
+        let result = partialRequest.replaceRequirement(id: id, how: mockTransformer)
+        
+        // Assert
+        XCTAssertFalse(wasCalled)
+        XCTAssertEqual((partialRequest.requirement as? GroupRequirement)?.requirements.count, 3)
+        XCTAssertEqual(((partialRequest.requirement as? GroupRequirement)?.requirements[0] as? VerifiedIdRequirement)?.id,
+                       verifiedIdRequirement.id)
+        XCTAssertEqual((partialRequest.requirement as? GroupRequirement)?.requirements[1] as? MockRequirement,
+                       mockRequirement1)
+        XCTAssertEqual((partialRequest.requirement as? GroupRequirement)?.requirements[2] as? MockRequirement,
+                       mockRequirement2)
+        XCTAssertNil(result)
+    }
+    
+    func testReplaceRequirement_With2GroupRequirements_ReturnsUpdatedRequirement() async throws
+    {
+        let id = "expectedId"
+        var wasCalled = false
+        let verifiedIdRequirement = VerifiedIdRequirement(encrypted: false,
+                                                        required: true,
+                                                        types: [],
+                                                        purpose: nil,
+                                                        issuanceOptions: [],
+                                                        id: id,
+                                                        constraint: MockConstraint(doesMatchResult: true))
+        let mockRequirement1 = MockRequirement(id: "wrongId")
+        let mockRequirement2 = MockRequirement(id: "wrongId2")
+        
+        let expectedResult = MockRequirement(id: id)
+        
+        let nestedRequirement = GroupRequirement(required: true,
+                                                requirements: [verifiedIdRequirement,
+                                                               mockRequirement1],
+                                                requirementOperator: .ALL)
+        
+        let groupRequirement = GroupRequirement(required: true,
+                                                requirements: [nestedRequirement,                                                                 mockRequirement2],
+                                                requirementOperator: .ALL)
+        
+        let mockTransformer: ((VerifiedIdRequirement) -> Requirement) = { req in
+            wasCalled = true
+            return expectedResult
+        }
+        
+        // Arrange
+        let partialRequest = VerifiedIdPartialRequest(requesterStyle: MockRequesterStyle(requester: ""),
+                                                      requirement: groupRequirement,
+                                                      rootOfTrust: RootOfTrust(verified: false, source: nil))
+        
+        // Act
+        let result = partialRequest.replaceRequirement(id: id, how: mockTransformer)
+        
+        // Assert
+        XCTAssert(wasCalled)
+        XCTAssertEqual((partialRequest.requirement as? GroupRequirement)?.requirements.count, 2)
+        XCTAssertEqual((partialRequest.requirement as? GroupRequirement)?.requirements[1] as? MockRequirement,
+                       mockRequirement2)
+        XCTAssertEqual((partialRequest.requirement as? GroupRequirement)?.requirements.count, 2)
+        let nestedRequirementResult = (partialRequest.requirement as? GroupRequirement)?.requirements[0] as? GroupRequirement
+        XCTAssertEqual(nestedRequirementResult?.requirements.count, 2)
+        XCTAssertEqual(nestedRequirementResult?.requirements[0] as? MockRequirement,
+                       expectedResult)
+        XCTAssertEqual(nestedRequirementResult?.requirements[1] as? MockRequirement,
+                       mockRequirement1)
+        XCTAssertEqual(result as? MockRequirement, expectedResult)
+    }
+}


### PR DESCRIPTION
**Problem:**
Extensions need the ability to replace requirements in requirement tree.


**Solution:**
Add a helper method to `VerifiedIdPartialRequest`.


**Validation:**
All unit tests pass.


**Type of change:**
- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.