### PR TITLE
[Issuance V2] Root Of Trust Convergence

### DIFF
--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCEntities/VCEntities/identifier/document/IdentifierDocument.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCEntities/VCEntities/identifier/document/IdentifierDocument.swift
@@ -3,7 +3,7 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-struct IdentifierDocument: Codable, Equatable {
+struct IdentifierDocument: Codable, Equatable, IdentifierMetadata {
     let id: String
     let service: [IdentifierDocumentServiceEndpointDescriptor]?
     let verificationMethod: [IdentifierDocumentPublicKey]?

--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/LinkedDomainService.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/LinkedDomainService.swift
@@ -29,8 +29,9 @@ class LinkedDomainService {
     func validateLinkedDomain(from identifierDocument: IdentifierDocument) async throws -> LinkedDomainResult {
         
         /// Try to resolve root of trust using root of trust resolver, fallback to old implementation if fails.
+        let identifier = AIdentifierDocument(id: identifierDocument.id, document: identifierDocument)
         if let rootOfTrustResolver = self.rootOfTrustResolver,
-           let rootOfTrust = try? await rootOfTrustResolver.resolve(did: identifierDocument.id)
+           let rootOfTrust = try? await rootOfTrustResolver.resolve(from: identifier)
         {
             return self.getLinkedDomainResult(from: rootOfTrust)
         }

--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/LinkedDomainService.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/LinkedDomainService.swift
@@ -29,9 +29,8 @@ class LinkedDomainService {
     func validateLinkedDomain(from identifierDocument: IdentifierDocument) async throws -> LinkedDomainResult {
         
         /// Try to resolve root of trust using root of trust resolver, fallback to old implementation if fails.
-        let identifier = AIdentifierDocument(id: identifierDocument.id, document: identifierDocument)
         if let rootOfTrustResolver = self.rootOfTrustResolver,
-           let rootOfTrust = try? await rootOfTrustResolver.resolve(from: identifier)
+           let rootOfTrust = try? await rootOfTrustResolver.resolve(from: identifierDocument)
         {
             return self.getLinkedDomainResult(from: rootOfTrust)
         }

--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		550E3212298B1150004E7716 /* VerifiedIdRequestInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550E3211298B1150004E7716 /* VerifiedIdRequestInput.swift */; };
 		550E3217298B1236004E7716 /* RequesterStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550E3216298B1236004E7716 /* RequesterStyle.swift */; };
 		551B9D502C8A31390007CE2B /* OpenID4VCIPreAuthTokenResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551B9D4E2C8A31390007CE2B /* OpenID4VCIPreAuthTokenResolverTests.swift */; };
+		551B9D522C8B94870007CE2B /* IdentifierMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551B9D512C8B94870007CE2B /* IdentifierMetadata.swift */; };
 		5524A53D29D2370E00C5F18D /* VerifiedIdDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BA2DD829CDFA6100BB8207 /* VerifiedIdDecoderTests.swift */; };
 		5524A59F29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5524A59E29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift */; };
 		5524A5B629D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5524A5B529D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift */; };
@@ -392,7 +393,6 @@
 		5555F1C52BACC8B700B41FD4 /* VerifiablePresentationFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5555F1C42BACC8B700B41FD4 /* VerifiablePresentationFormatterTests.swift */; };
 		555FB16A2B73FBB000EE14BD /* CredentialOfferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB1692B73FBB000EE14BD /* CredentialOfferTests.swift */; };
 		555FB1B62B740A3000EE14BD /* OpenId4VCIProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB1B52B740A3000EE14BD /* OpenId4VCIProcessorTests.swift */; };
-		555FB1D72B74400300EE14BD /* RootOfTrustResolving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB1D62B74400300EE14BD /* RootOfTrustResolving.swift */; };
 		555FB1DB2B74406400EE14BD /* SignedCredentialMetadataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB1DA2B74406400EE14BD /* SignedCredentialMetadataProcessor.swift */; };
 		555FB1F72B75657900EE14BD /* DIDDocumentResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB1F62B75657900EE14BD /* DIDDocumentResolver.swift */; };
 		555FB1FD2B75660500EE14BD /* LinkedDomainResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB1FC2B75660500EE14BD /* LinkedDomainResolver.swift */; };
@@ -621,6 +621,7 @@
 		550E3211298B1150004E7716 /* VerifiedIdRequestInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerifiedIdRequestInput.swift; sourceTree = "<group>"; };
 		550E3216298B1236004E7716 /* RequesterStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequesterStyle.swift; sourceTree = "<group>"; };
 		551B9D4E2C8A31390007CE2B /* OpenID4VCIPreAuthTokenResolverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenID4VCIPreAuthTokenResolverTests.swift; sourceTree = "<group>"; };
+		551B9D512C8B94870007CE2B /* IdentifierMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierMetadata.swift; sourceTree = "<group>"; };
 		5524A59E29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLibraryVCSDKLogConsumer.swift; sourceTree = "<group>"; };
 		5524A5B529D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLibraryVCSDKLogConsumerTests.swift; sourceTree = "<group>"; };
 		5524A5F629D634BC00C5F18D /* VerifiedIdLogo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerifiedIdLogo.swift; sourceTree = "<group>"; };
@@ -986,7 +987,6 @@
 		5555F1C42BACC8B700B41FD4 /* VerifiablePresentationFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiablePresentationFormatterTests.swift; sourceTree = "<group>"; };
 		555FB1692B73FBB000EE14BD /* CredentialOfferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialOfferTests.swift; sourceTree = "<group>"; };
 		555FB1B52B740A3000EE14BD /* OpenId4VCIProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenId4VCIProcessorTests.swift; sourceTree = "<group>"; };
-		555FB1D62B74400300EE14BD /* RootOfTrustResolving.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RootOfTrustResolving.swift; path = WalletLibrary/Protocols/RootOfTrust/RootOfTrustResolving.swift; sourceTree = SOURCE_ROOT; };
 		555FB1DA2B74406400EE14BD /* SignedCredentialMetadataProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedCredentialMetadataProcessor.swift; sourceTree = "<group>"; };
 		555FB1F62B75657900EE14BD /* DIDDocumentResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIDDocumentResolver.swift; sourceTree = "<group>"; };
 		555FB1FC2B75660500EE14BD /* LinkedDomainResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedDomainResolver.swift; sourceTree = "<group>"; };
@@ -2503,6 +2503,7 @@
 			children = (
 				5555F19F2BA9F67C00B41FD4 /* ExtensionIdentifierManager.swift */,
 				55265ACE2B61B0D600BAD6A2 /* IdentifierManager.swift */,
+				551B9D512C8B94870007CE2B /* IdentifierMetadata.swift */,
 			);
 			path = Identifier;
 			sourceTree = "<group>";
@@ -2588,7 +2589,7 @@
 		555FB1F92B7565BA00EE14BD /* RootOfTrust */ = {
 			isa = PBXGroup;
 			children = (
-				555FB1D62B74400300EE14BD /* RootOfTrustResolving.swift */,
+				55A6390C2BB711CC00BE2AF2 /* RootOfTrustResolver.swift */,
 				555FB2152B75A2A900EE14BD /* IdentifierDocumentResolving.swift */,
 			);
 			path = RootOfTrust;
@@ -3129,7 +3130,6 @@
 		55E337B62948B4F900CD2ED7 /* Requests */ = {
 			isa = PBXGroup;
 			children = (
-				55A6390C2BB711CC00BE2AF2 /* RootOfTrustResolver.swift */,
 				A4D9F9C52B7AF277006D074E /* ProcessorExtensions */,
 				558168DA2BA8B5EE000E9CA5 /* Processors */,
 				55255F1E2C0E49AF0092CFC3 /* Requirements */,
@@ -3484,6 +3484,7 @@
 				55E336D6293FA78C00CD2ED7 /* VerifiedIdClaim.swift in Sources */,
 				5552D3C729EF489E00B40302 /* IONDocumentInitialState.swift in Sources */,
 				553CC09029A955E6005A5FD6 /* PinDescriptor+Mappable.swift in Sources */,
+				551B9D522C8B94870007CE2B /* IdentifierMetadata.swift in Sources */,
 				55255F292C1793810092CFC3 /* OpenIDWellKnownConfiguration.swift in Sources */,
 				55265AF52B6D765D00BAD6A2 /* CredentialMetadata.swift in Sources */,
 				5552D4B829EF4AC300B40302 /* Aes.swift in Sources */,
@@ -3518,7 +3519,6 @@
 				5552D44229EF4A8100B40302 /* WellKnownConfigDocumentNetworkCalls.swift in Sources */,
 				5534E5B52948FEB5005D0765 /* RootOfTrust.swift in Sources */,
 				555FB2162B75A2A900EE14BD /* IdentifierDocumentResolving.swift in Sources */,
-				555FB1D72B74400300EE14BD /* RootOfTrustResolving.swift in Sources */,
 				5552D40A29EF490A00B40302 /* PresentationExchangeConstraints.swift in Sources */,
 				5552D3B929EF487600B40302 /* FormatterError.swift in Sources */,
 				555FB1FD2B75660500EE14BD /* LinkedDomainResolver.swift in Sources */,

--- a/WalletLibrary/WalletLibrary/Protocols/Identifier/IdentifierMetadata.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Identifier/IdentifierMetadata.swift
@@ -3,14 +3,9 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-/// Allows a different way of resolving the root of trust (aka Linked Domain Result)
-/// that can be injected into Issuance and Presentation Service.
-public protocol RootOfTrustResolver {
-    func resolve(from identifier: IdentifierMetadata) async throws -> RootOfTrust
-}
-
-public protocol IdentifierMetadata {
+/// Describes the metadata for an Identifier object.
+public protocol IdentifierMetadata
+{
+    /// The identifying string for this object. (for example: did:web:microsoft.com)
     var id: String { get }
 }
-
-

--- a/WalletLibrary/WalletLibrary/Protocols/Identifier/IdentifierMetadata.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Identifier/IdentifierMetadata.swift
@@ -3,7 +3,10 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-/// Describes the metadata for an Identifier object.
+/**
+ * Defines the metadata for an Identifier object.
+ * This metadata might be an Identifier Document or used to determine the root of trust.
+ */
 public protocol IdentifierMetadata
 {
     /// The identifying string for this object. (for example: did:web:microsoft.com)

--- a/WalletLibrary/WalletLibrary/Protocols/Requests/RootOfTrustResolver.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Requests/RootOfTrustResolver.swift
@@ -6,18 +6,11 @@
 /// Allows a different way of resolving the root of trust (aka Linked Domain Result)
 /// that can be injected into Issuance and Presentation Service.
 public protocol RootOfTrustResolver {
-    func resolve(from identifier: AIdentifier) async throws -> RootOfTrust
+    func resolve(from identifier: IdentifierMetadata) async throws -> RootOfTrust
 }
 
-public protocol AIdentifier {
+public protocol IdentifierMetadata {
     var id: String { get }
-}
-
-struct AIdentifierDocument: AIdentifier
-{
-    let id: String
-    
-    let document: IdentifierDocument
 }
 
 

--- a/WalletLibrary/WalletLibrary/Protocols/Requests/RootOfTrustResolver.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Requests/RootOfTrustResolver.swift
@@ -6,5 +6,18 @@
 /// Allows a different way of resolving the root of trust (aka Linked Domain Result)
 /// that can be injected into Issuance and Presentation Service.
 public protocol RootOfTrustResolver {
-    func resolve(did: String) async throws -> RootOfTrust
+    func resolve(from identifier: AIdentifier) async throws -> RootOfTrust
 }
+
+public protocol AIdentifier {
+    var id: String { get }
+}
+
+struct AIdentifierDocument: AIdentifier
+{
+    let id: String
+    
+    let document: IdentifierDocument
+}
+
+

--- a/WalletLibrary/WalletLibrary/Protocols/RootOfTrust/RootOfTrustResolver.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/RootOfTrust/RootOfTrustResolver.swift
@@ -3,10 +3,9 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-/**
- * Defines the behavior of resolving the Root of Trust (aka Linked Domain Result).
- */
-//protocol RootOfTrustResolving
-//{
-//    func resolve(using identifier: IdentifierDocument) async throws -> RootOfTrust
-//}
+/// Allows a different way of resolving the root of trust (aka Linked Domain Result)
+/// that can be injected into Issuance and Presentation Service.
+public protocol RootOfTrustResolver 
+{
+    func resolve(from identifier: IdentifierMetadata) async throws -> RootOfTrust
+}

--- a/WalletLibrary/WalletLibrary/Protocols/RootOfTrust/RootOfTrustResolver.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/RootOfTrust/RootOfTrustResolver.swift
@@ -3,9 +3,13 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-/// Allows a different way of resolving the root of trust (aka Linked Domain Result)
-/// that can be injected into Issuance and Presentation Service.
+/**
+ * Defines the behavior of resolving the Root of Trust.
+ * An implementation of this protocol can be injected into the VerifiedIdClient.
+ */
 public protocol RootOfTrustResolver 
 {
+    /// Resolve the `RootOfTrust` from the given `IdentifierMetadata` to determine whether the
+    /// identifier can be trusted. (for example: Linked Domain)
     func resolve(from identifier: IdentifierMetadata) async throws -> RootOfTrust
 }

--- a/WalletLibrary/WalletLibrary/Protocols/RootOfTrust/RootOfTrustResolving.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/RootOfTrust/RootOfTrustResolving.swift
@@ -6,7 +6,7 @@
 /**
  * Defines the behavior of resolving the Root of Trust (aka Linked Domain Result).
  */
-protocol RootOfTrustResolving
-{
-    func resolve(using identifier: IdentifierDocument) async throws -> RootOfTrust
-}
+//protocol RootOfTrustResolving
+//{
+//    func resolve(using identifier: IdentifierDocument) async throws -> RootOfTrust
+//}

--- a/WalletLibrary/WalletLibrary/Requests/Processors/SignedCredentialMetadataProcessor.swift
+++ b/WalletLibrary/WalletLibrary/Requests/Processors/SignedCredentialMetadataProcessor.swift
@@ -73,8 +73,7 @@ struct SignedCredentialMetadataProcessor: SignedCredentialMetadataProcessing
                                                                          error: error)
         }
         
-        let identifier = AIdentifierDocument(id: kid.did, document: identifierDocument)
-        return try await rootOfTrustResolver.resolve(from: identifier)
+        return try await rootOfTrustResolver.resolve(from: identifierDocument)
     }
     
     private func validateSignature(signedMetadata: SignedMetadata, using key: JWK) throws

--- a/WalletLibrary/WalletLibrary/RootOfTrust/Resolvers/LinkedDomainResolver.swift
+++ b/WalletLibrary/WalletLibrary/RootOfTrust/Resolvers/LinkedDomainResolver.swift
@@ -6,7 +6,7 @@
 /**
  * Responsible for resolving the Root of Trust through the Linked Domain.
  */
-struct LinkedDomainResolver: RootOfTrustResolving
+struct LinkedDomainResolver: RootOfTrustResolver
 {
     private let linkedDomainService: LinkedDomainService
     
@@ -30,9 +30,13 @@ struct LinkedDomainResolver: RootOfTrustResolving
     /// Resolves the Root of Trust through Linked Domains.
     /// - Parameters:
     ///   - identifier: An identifier used to resolve the Linked Domains. This should be the `IdentifierDocument` in this case.
-    func resolve(using identifier: IdentifierDocument) async throws -> RootOfTrust
-    { 
-        let linkedDomain = try await linkedDomainService.validateLinkedDomain(from: identifier)
+    func resolve(from identifier: AIdentifier) async throws -> RootOfTrust
+    {
+        guard let identifier = identifier as? AIdentifierDocument else
+        {
+            throw VerifiedIdError(message: "", code: "")
+        }
+        let linkedDomain = try await linkedDomainService.validateLinkedDomain(from: identifier.document)
         return try configuration.mapper.map(linkedDomain)
     }
 }

--- a/WalletLibrary/WalletLibrary/RootOfTrust/Resolvers/LinkedDomainResolver.swift
+++ b/WalletLibrary/WalletLibrary/RootOfTrust/Resolvers/LinkedDomainResolver.swift
@@ -34,7 +34,7 @@ struct LinkedDomainResolver: RootOfTrustResolver
     {
         guard let identifierDocument = identifier as? IdentifierDocument else
         {
-            throw VerifiedIdError(message: "", code: "")
+            throw VerifiedIdErrors.MalformedInput(message: "Expected an Identifier Document to resolve Root of Trust.").error
         }
         
         let linkedDomain = try await linkedDomainService.validateLinkedDomain(from: identifierDocument)

--- a/WalletLibrary/WalletLibrary/RootOfTrust/Resolvers/LinkedDomainResolver.swift
+++ b/WalletLibrary/WalletLibrary/RootOfTrust/Resolvers/LinkedDomainResolver.swift
@@ -30,13 +30,14 @@ struct LinkedDomainResolver: RootOfTrustResolver
     /// Resolves the Root of Trust through Linked Domains.
     /// - Parameters:
     ///   - identifier: An identifier used to resolve the Linked Domains. This should be the `IdentifierDocument` in this case.
-    func resolve(from identifier: AIdentifier) async throws -> RootOfTrust
+    func resolve(from identifier: IdentifierMetadata) async throws -> RootOfTrust
     {
-        guard let identifier = identifier as? AIdentifierDocument else
+        guard let identifierDocument = identifier as? IdentifierDocument else
         {
             throw VerifiedIdError(message: "", code: "")
         }
-        let linkedDomain = try await linkedDomainService.validateLinkedDomain(from: identifier.document)
+        
+        let linkedDomain = try await linkedDomainService.validateLinkedDomain(from: identifierDocument)
         return try configuration.mapper.map(linkedDomain)
     }
 }

--- a/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
@@ -142,7 +142,9 @@ public class VerifiedIdClientBuilder {
                                                      verifiableCredentialRequester: issuanceService)
         requestProcessors.append(openIdProcessor)
         
-        let openId4VCIProcessor = OpenId4VCIProcessor(configuration: configuration)
+        let credMetadataProcessor = SignedCredentialMetadataProcessor(configuration: configuration,
+                                                                      rootOfTrustResolver: rootOfTrustResolver)
+        let openId4VCIProcessor = OpenId4VCIProcessor(configuration: configuration, signedMetadataProcessor: credMetadataProcessor)
         requestProcessors.append(openId4VCIProcessor)
     }
     


### PR DESCRIPTION
**Problem:**
The new Issuance V2 flows did not allow for `RootOfTrustResolver` injection from the `VerifiedIdClientBuilder` because of differences in the  internal `RootOfTrustResolving` and public `RootOfTrustResolver` protocol (only in our "internal/release" branch").


**Solution:**
Converge the two protocols with a new abstract protocol called `IdentifierMetadata`. 


**Validation:**
Issuance v2 flows are able to use an injected RootOfTrustResolver properly.


**Type of change:**
- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.

`NOTE`: The naming of `IdentifierMetadata` is subject to change until we complete the Wallet Library bifurcation and `DID:JWK` work.

**Documentation Links**:
Please include here links to any related background documentation for this PR.