### PR TITLE
Support Injection of a Root Of Trust Resolver

### DIFF
--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCEntities/VCEntities/identifier/document/IdentifierDocument.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCEntities/VCEntities/identifier/document/IdentifierDocument.swift
@@ -3,7 +3,7 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-struct IdentifierDocument: Codable, Equatable {
+struct IdentifierDocument: Codable, Equatable, IdentifierMetadata {
     let id: String
     let service: [IdentifierDocumentServiceEndpointDescriptor]?
     let verificationMethod: [IdentifierDocumentPublicKey]?

--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCEntities/VCEntities/identifier/document/IdentifierDocument.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCEntities/VCEntities/identifier/document/IdentifierDocument.swift
@@ -3,7 +3,9 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-struct IdentifierDocument: Codable, Equatable, IdentifierMetadata {
+/// Defines the data model for a Public Identifier Document used to verify an issuer/verifier.
+struct IdentifierDocument: Codable, Equatable, IdentifierMetadata
+{
     let id: String
     let service: [IdentifierDocumentServiceEndpointDescriptor]?
     let verificationMethod: [IdentifierDocumentPublicKey]?

--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/IssuanceService.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/IssuanceService.swift
@@ -21,6 +21,7 @@ class IssuanceService {
     private let sdkLog: VCSDKLog
     
     convenience init(correlationVector: VerifiedIdCorrelationHeader? = nil,
+                     rootOfTrustResolver: RootOfTrustResolver? = nil,
                      urlSession: URLSession) {
         self.init(formatter: IssuanceResponseFormatter(),
                   apiCalls: IssuanceNetworkCalls(correlationVector: correlationVector,
@@ -30,6 +31,7 @@ class IssuanceService {
                   requestValidator: IssuanceRequestValidator(),
                   identifierService: IdentifierService(),
                   linkedDomainService: LinkedDomainService(correlationVector: correlationVector,
+                                                           rootOfTrustResolver: rootOfTrustResolver,
                                                            urlSession: urlSession),
                   sdkLog: VCSDKLog.sharedInstance)
     }

--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/LinkedDomainService.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/LinkedDomainService.swift
@@ -23,6 +23,13 @@ class LinkedDomainService {
     
     func validateLinkedDomain(from identifierDocument: IdentifierDocument) async throws -> LinkedDomainResult {
         
+        /// Try to resolve root of trust using root of trust resolver, fallback to old implementation if fails.
+        if let rootOfTrustResolver = self.rootOfTrustResolver,
+           let rootOfTrust = try? await rootOfTrustResolver.resolve(from: identifierDocument)
+        {
+            return self.getLinkedDomainResult(from: rootOfTrust)
+        }
+        
         guard let service = identifierDocument.service,
               let domainUrl = getLinkedDomainUrl(from: service) else {
             return .linkedDomainMissing

--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/LinkedDomainService.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/LinkedDomainService.swift
@@ -7,6 +7,8 @@ class LinkedDomainService {
     
     private let wellKnownDocumentApiCalls: WellKnownConfigDocumentNetworking
     private let validator: DomainLinkageCredentialValidating
+    
+    /// An optional Root of Trust Resolver that if injected, will be used first before trying to resolve using the Linked Domain mechanism.
     private let rootOfTrustResolver: RootOfTrustResolver?
     
     convenience init(correlationVector: VerifiedIdCorrelationHeader? = nil,
@@ -26,8 +28,8 @@ class LinkedDomainService {
         self.validator = domainLinkageValidator
     }
     
-    func validateLinkedDomain(from identifierDocument: IdentifierDocument) async throws -> LinkedDomainResult {
-        
+    func validateLinkedDomain(from identifierDocument: IdentifierDocument) async throws -> LinkedDomainResult 
+    {
         /// Try to resolve root of trust using root of trust resolver, fallback to old implementation if fails.
         if let rootOfTrustResolver = self.rootOfTrustResolver,
            let rootOfTrust = try? await rootOfTrustResolver.resolve(from: identifierDocument)

--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/PresentationService.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/PresentationService.swift
@@ -16,6 +16,7 @@ enum PresentationServiceError: Error {
     case noIssuerIdentifierInRequest
 }
 
+// TODO: replace during FIPS work.
 class PresentationService {
     
     let formatter: PresentationResponseFormatting
@@ -27,7 +28,8 @@ class PresentationService {
     private let sdkLog: VCSDKLog
     
     convenience init(correlationVector: VerifiedIdCorrelationHeader? = nil,
-                     urlSession: URLSession = URLSession.shared) {
+                     rootOfTrustResolver: RootOfTrustResolver?,
+                     urlSession: URLSession) {
         self.init(formatter: PresentationResponseFormatter(sdkLog: VCSDKLog.sharedInstance),
                   presentationApiCalls: PresentationNetworkCalls(correlationVector: correlationVector,
                                                                  urlSession: urlSession),
@@ -35,6 +37,7 @@ class PresentationService {
                                                                         urlSession: urlSession),
                   requestValidator: PresentationRequestValidator(),
                   linkedDomainService: LinkedDomainService(correlationVector: correlationVector,
+                                                           rootOfTrustResolver: rootOfTrustResolver,
                                                            urlSession: urlSession),
                   identifierService: IdentifierService(),
                   sdkLog: VCSDKLog.sharedInstance)

--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		550E3210298B113C004E7716 /* VerifiedIdRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550E320F298B113C004E7716 /* VerifiedIdRequest.swift */; };
 		550E3212298B1150004E7716 /* VerifiedIdRequestInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550E3211298B1150004E7716 /* VerifiedIdRequestInput.swift */; };
 		550E3217298B1236004E7716 /* RequesterStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550E3216298B1236004E7716 /* RequesterStyle.swift */; };
+		551B9EC72CADC2EA0007CE2B /* RootOfTrustResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551B9EC62CADC2EA0007CE2B /* RootOfTrustResolver.swift */; };
+		551B9EC92CADC33C0007CE2B /* IdentifierMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551B9EC82CADC33C0007CE2B /* IdentifierMetadata.swift */; };
 		5524A53D29D2370E00C5F18D /* VerifiedIdDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BA2DD829CDFA6100BB8207 /* VerifiedIdDecoderTests.swift */; };
 		5524A59F29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5524A59E29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift */; };
 		5524A5B629D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5524A5B529D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift */; };
@@ -610,6 +612,8 @@
 		550E320F298B113C004E7716 /* VerifiedIdRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerifiedIdRequest.swift; sourceTree = "<group>"; };
 		550E3211298B1150004E7716 /* VerifiedIdRequestInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerifiedIdRequestInput.swift; sourceTree = "<group>"; };
 		550E3216298B1236004E7716 /* RequesterStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequesterStyle.swift; sourceTree = "<group>"; };
+		551B9EC62CADC2EA0007CE2B /* RootOfTrustResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RootOfTrustResolver.swift; path = WalletLibrary/Protocols/RootOfTrust/RootOfTrustResolver.swift; sourceTree = SOURCE_ROOT; };
+		551B9EC82CADC33C0007CE2B /* IdentifierMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IdentifierMetadata.swift; path = WalletLibrary/Protocols/Identifier/IdentifierMetadata.swift; sourceTree = SOURCE_ROOT; };
 		5524A59E29D5FDA500C5F18D /* WalletLibraryVCSDKLogConsumer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLibraryVCSDKLogConsumer.swift; sourceTree = "<group>"; };
 		5524A5B529D6016500C5F18D /* WalletLibraryVCSDKLogConsumerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletLibraryVCSDKLogConsumerTests.swift; sourceTree = "<group>"; };
 		5524A5F629D634BC00C5F18D /* VerifiedIdLogo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerifiedIdLogo.swift; sourceTree = "<group>"; };
@@ -2451,9 +2455,9 @@
 		5555F19E2BA9F66400B41FD4 /* Identifier */ = {
 			isa = PBXGroup;
 			children = (
+				551B9EC82CADC33C0007CE2B /* IdentifierMetadata.swift */,
 				5555F19F2BA9F67C00B41FD4 /* ExtensionIdentifierManager.swift */,
 				55265ACE2B61B0D600BAD6A2 /* IdentifierManager.swift */,
-				551B9D512C8B94870007CE2B /* IdentifierMetadata.swift */,
 			);
 			path = Identifier;
 			sourceTree = "<group>";
@@ -2538,7 +2542,7 @@
 		555FB1F92B7565BA00EE14BD /* RootOfTrust */ = {
 			isa = PBXGroup;
 			children = (
-				55A6390C2BB711CC00BE2AF2 /* RootOfTrustResolver.swift */,
+				551B9EC62CADC2EA0007CE2B /* RootOfTrustResolver.swift */,
 				555FB2152B75A2A900EE14BD /* IdentifierDocumentResolving.swift */,
 			);
 			path = RootOfTrust;
@@ -3553,6 +3557,7 @@
 				5552D3FB29EF48F100B40302 /* BackupProtectionMethod.swift in Sources */,
 				5552D3E929EF48E200B40302 /* PresentationResponseClaims.swift in Sources */,
 				5552D40629EF490A00B40302 /* InputDescriptorSchema.swift in Sources */,
+				551B9EC92CADC33C0007CE2B /* IdentifierMetadata.swift in Sources */,
 				55E3370C293FD61E00CD2ED7 /* SelfAttestedClaimRequirement.swift in Sources */,
 				55A4BB3F2A2A5576006836AB /* VerifiedIdErrors.swift in Sources */,
 				5552D48129EF4AAB00B40302 /* VCTokenError.swift in Sources */,
@@ -3589,6 +3594,7 @@
 				55A81BE12991AB96002C259A /* RequestProcessing.swift in Sources */,
 				5552D40029EF490000B40302 /* VPTokenResponseDescription.swift in Sources */,
 				55E2F071299554110008010D /* LibraryConfiguration.swift in Sources */,
+				551B9EC72CADC2EA0007CE2B /* RootOfTrustResolver.swift in Sources */,
 				55265B012B6D938800BAD6A2 /* OpenIDRequestFetchNetworkOperation.swift in Sources */,
 				5552D4CE29EF4AC300B40302 /* SecretStoring.swift in Sources */,
 				550E3209298B0EA4004E7716 /* VerifiedIdClientBuilder.swift in Sources */,

--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -385,7 +385,6 @@
 		5555F1C52BACC8B700B41FD4 /* VerifiablePresentationFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5555F1C42BACC8B700B41FD4 /* VerifiablePresentationFormatterTests.swift */; };
 		555FB16A2B73FBB000EE14BD /* CredentialOfferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB1692B73FBB000EE14BD /* CredentialOfferTests.swift */; };
 		555FB1B62B740A3000EE14BD /* OpenId4VCIProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB1B52B740A3000EE14BD /* OpenId4VCIProcessorTests.swift */; };
-		555FB1D72B74400300EE14BD /* RootOfTrustResolving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB1D62B74400300EE14BD /* RootOfTrustResolving.swift */; };
 		555FB1DB2B74406400EE14BD /* SignedCredentialMetadataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB1DA2B74406400EE14BD /* SignedCredentialMetadataProcessor.swift */; };
 		555FB1F72B75657900EE14BD /* DIDDocumentResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB1F62B75657900EE14BD /* DIDDocumentResolver.swift */; };
 		555FB1FD2B75660500EE14BD /* LinkedDomainResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555FB1FC2B75660500EE14BD /* LinkedDomainResolver.swift */; };
@@ -970,7 +969,6 @@
 		5555F1C42BACC8B700B41FD4 /* VerifiablePresentationFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiablePresentationFormatterTests.swift; sourceTree = "<group>"; };
 		555FB1692B73FBB000EE14BD /* CredentialOfferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialOfferTests.swift; sourceTree = "<group>"; };
 		555FB1B52B740A3000EE14BD /* OpenId4VCIProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenId4VCIProcessorTests.swift; sourceTree = "<group>"; };
-		555FB1D62B74400300EE14BD /* RootOfTrustResolving.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RootOfTrustResolving.swift; path = WalletLibrary/Protocols/RootOfTrust/RootOfTrustResolving.swift; sourceTree = SOURCE_ROOT; };
 		555FB1DA2B74406400EE14BD /* SignedCredentialMetadataProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedCredentialMetadataProcessor.swift; sourceTree = "<group>"; };
 		555FB1F62B75657900EE14BD /* DIDDocumentResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIDDocumentResolver.swift; sourceTree = "<group>"; };
 		555FB1FC2B75660500EE14BD /* LinkedDomainResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedDomainResolver.swift; sourceTree = "<group>"; };
@@ -2455,6 +2453,7 @@
 			children = (
 				5555F19F2BA9F67C00B41FD4 /* ExtensionIdentifierManager.swift */,
 				55265ACE2B61B0D600BAD6A2 /* IdentifierManager.swift */,
+				551B9D512C8B94870007CE2B /* IdentifierMetadata.swift */,
 			);
 			path = Identifier;
 			sourceTree = "<group>";
@@ -2539,7 +2538,7 @@
 		555FB1F92B7565BA00EE14BD /* RootOfTrust */ = {
 			isa = PBXGroup;
 			children = (
-				555FB1D62B74400300EE14BD /* RootOfTrustResolving.swift */,
+				55A6390C2BB711CC00BE2AF2 /* RootOfTrustResolver.swift */,
 				555FB2152B75A2A900EE14BD /* IdentifierDocumentResolving.swift */,
 			);
 			path = RootOfTrust;
@@ -3477,7 +3476,6 @@
 				5534E5B52948FEB5005D0765 /* RootOfTrust.swift in Sources */,
 				557539DD2BBDF263009E1257 /* VerifiableCredentialSerializer.swift in Sources */,
 				555FB2162B75A2A900EE14BD /* IdentifierDocumentResolving.swift in Sources */,
-				555FB1D72B74400300EE14BD /* RootOfTrustResolving.swift in Sources */,
 				5552D40A29EF490A00B40302 /* PresentationExchangeConstraints.swift in Sources */,
 				5552D3B929EF487600B40302 /* FormatterError.swift in Sources */,
 				555FB1FD2B75660500EE14BD /* LinkedDomainResolver.swift in Sources */,

--- a/WalletLibrary/WalletLibrary/Protocols/Identifier/IdentifierMetadata.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Identifier/IdentifierMetadata.swift
@@ -4,9 +4,11 @@
 *--------------------------------------------------------------------------------------------*/
 
 /**
- * Defines the behavior of resolving the Root of Trust (aka Linked Domain Result).
+ * Defines the metadata for an Identifier object.
+ * This metadata might be an Identifier Document or used to determine the root of trust.
  */
-protocol RootOfTrustResolving
+public protocol IdentifierMetadata
 {
-    func resolve(using identifier: IdentifierDocument) async throws -> RootOfTrust
+    /// The identifying string for this object. (for example: did:web:microsoft.com)
+    var id: String { get }
 }

--- a/WalletLibrary/WalletLibrary/Protocols/Identifier/IdentifierMetadata.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Identifier/IdentifierMetadata.swift
@@ -4,8 +4,8 @@
 *--------------------------------------------------------------------------------------------*/
 
 /**
- * Defines the metadata for an Identifier object.
- * This metadata might be an Identifier Document or used to determine the root of trust.
+ * Defines the metadata for an public Identifier object that defines an issuer/verifier.
+ * This metadata might be an Identifier Document and can be used to determine the root of trust.
  */
 public protocol IdentifierMetadata
 {

--- a/WalletLibrary/WalletLibrary/Protocols/RootOfTrust/RootOfTrustResolver.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/RootOfTrust/RootOfTrustResolver.swift
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+/**
+ * Defines the behavior of resolving the Root of Trust.
+ * An implementation of this protocol can be injected into the VerifiedIdClient.
+ */
+public protocol RootOfTrustResolver 
+{
+    /// Resolve the `RootOfTrust` from the given `IdentifierMetadata` to determine whether the
+    /// identifier can be trusted. (for example: Linked Domain)
+    func resolve(from identifier: IdentifierMetadata) async throws -> RootOfTrust
+}

--- a/WalletLibrary/WalletLibrary/Requests/Processors/SignedCredentialMetadataProcessor.swift
+++ b/WalletLibrary/WalletLibrary/Requests/Processors/SignedCredentialMetadataProcessor.swift
@@ -12,22 +12,22 @@ struct SignedCredentialMetadataProcessor: SignedCredentialMetadataProcessing
     
     private let identifierDocumentResolver: IdentifierDocumentResolving
     
-    private let rootOfTrustResolver: RootOfTrustResolving
+    private let rootOfTrustResolver: RootOfTrustResolver
     
     init(tokenVerifier: TokenVerifying, 
          identifierDocumentResolver: IdentifierDocumentResolving,
-         rootOfTrustResolver: RootOfTrustResolving)
+         rootOfTrustResolver: RootOfTrustResolver)
     {
         self.tokenVerifier = tokenVerifier
         self.identifierDocumentResolver = identifierDocumentResolver
         self.rootOfTrustResolver = rootOfTrustResolver
     }
     
-    init(configuration: LibraryConfiguration)
+    init(configuration: LibraryConfiguration, rootOfTrustResolver: RootOfTrustResolver? = nil)
     {
         self.init(tokenVerifier: TokenVerifier(),
                   identifierDocumentResolver: DIDDocumentResolver(configuration: configuration),
-                  rootOfTrustResolver: LinkedDomainResolver(configuration: configuration))
+                  rootOfTrustResolver: rootOfTrustResolver ?? LinkedDomainResolver(configuration: configuration))
     }
     
     /// Processes the signed metadata, verifying its integrity and authenticity, and resolving the root of trust.
@@ -73,7 +73,7 @@ struct SignedCredentialMetadataProcessor: SignedCredentialMetadataProcessing
                                                                          error: error)
         }
         
-        return try await rootOfTrustResolver.resolve(using: identifierDocument)
+        return try await rootOfTrustResolver.resolve(from: identifierDocument)
     }
     
     private func validateSignature(signedMetadata: SignedMetadata, using key: JWK) throws

--- a/WalletLibrary/WalletLibrary/RootOfTrust/Resolvers/LinkedDomainResolver.swift
+++ b/WalletLibrary/WalletLibrary/RootOfTrust/Resolvers/LinkedDomainResolver.swift
@@ -6,7 +6,7 @@
 /**
  * Responsible for resolving the Root of Trust through the Linked Domain.
  */
-struct LinkedDomainResolver: RootOfTrustResolving
+struct LinkedDomainResolver: RootOfTrustResolver
 {
     private let linkedDomainService: LinkedDomainService
     
@@ -30,9 +30,14 @@ struct LinkedDomainResolver: RootOfTrustResolving
     /// Resolves the Root of Trust through Linked Domains.
     /// - Parameters:
     ///   - identifier: An identifier used to resolve the Linked Domains. This should be the `IdentifierDocument` in this case.
-    func resolve(using identifier: IdentifierDocument) async throws -> RootOfTrust
-    { 
-        let linkedDomain = try await linkedDomainService.validateLinkedDomain(from: identifier)
+    func resolve(from identifier: IdentifierMetadata) async throws -> RootOfTrust
+    {
+        guard let identifierDocument = identifier as? IdentifierDocument else
+        {
+            throw VerifiedIdErrors.MalformedInput(message: "Expected an Identifier Document to resolve Root of Trust.").error
+        }
+        
+        let linkedDomain = try await linkedDomainService.validateLinkedDomain(from: identifierDocument)
         return try configuration.mapper.map(linkedDomain)
     }
 }

--- a/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
@@ -118,7 +118,9 @@ public class VerifiedIdClientBuilder {
                                                      verifiableCredentialRequester: issuanceService)
         requestProcessors.append(openIdProcessor)
         
-        let openId4VCIProcessor = OpenId4VCIProcessor(configuration: configuration)
+        let credMetadataProcessor = SignedCredentialMetadataProcessor(configuration: configuration,
+                                                                      rootOfTrustResolver: rootOfTrustResolver)
+        let openId4VCIProcessor = OpenId4VCIProcessor(configuration: configuration, signedMetadataProcessor: credMetadataProcessor)
         requestProcessors.append(openId4VCIProcessor)
     }
     

--- a/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
@@ -107,7 +107,10 @@ public class VerifiedIdClientBuilder {
     }
     
     private func registerSupportedResolvers(with configuration: LibraryConfiguration) {
-        let openIdURLResolver = OpenIdURLRequestResolver(openIdResolver: PresentationService(),
+        let presentationService = PresentationService(correlationVector: correlationHeader,
+                                                      rootOfTrustResolver: rootOfTrustResolver,
+                                                      urlSession: urlSession)
+        let openIdURLResolver = OpenIdURLRequestResolver(openIdResolver: presentationService,
                                                          configuration: configuration)
         requestResolvers.append(openIdURLResolver)
     }
@@ -115,8 +118,10 @@ public class VerifiedIdClientBuilder {
     private func registerSupportedRequestProcessors(with configuration: LibraryConfiguration)
     {
         let issuanceService = IssuanceService(correlationVector: correlationHeader,
+                                              rootOfTrustResolver: rootOfTrustResolver,
                                               urlSession: urlSession)
         let presentationService = PresentationService(correlationVector: correlationHeader,
+                                                      rootOfTrustResolver: rootOfTrustResolver,
                                                       urlSession: urlSession)
         
         let openIdProcessor = OpenIdRequestProcessor(configuration: configuration,

--- a/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
@@ -20,6 +20,8 @@ public class VerifiedIdClientBuilder {
     
     private var requestProcessors: [any RequestProcessing] = []
     
+    private var rootOfTrustResolver: RootOfTrustResolver?
+    
     private var extensions: [VerifiedIdExtendable] = []
     
     private var previewFeatureFlagsSupported: [String] = []
@@ -66,6 +68,11 @@ public class VerifiedIdClientBuilder {
     public func with(previewFeatureFlags: [String]) -> VerifiedIdClientBuilder
     {
         previewFeatureFlagsSupported.append(contentsOf: previewFeatureFlags)
+        return self
+    }
+    
+    public func with(rootOfTrustResolver: RootOfTrustResolver) -> VerifiedIdClientBuilder {
+        self.rootOfTrustResolver = rootOfTrustResolver
         return self
     }
 

--- a/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
@@ -71,6 +71,7 @@ public class VerifiedIdClientBuilder {
         return self
     }
     
+    /// Optional method to add a custom Root of Trust Resolver to the VerifiedIdClient.
     public func with(rootOfTrustResolver: RootOfTrustResolver) -> VerifiedIdClientBuilder {
         self.rootOfTrustResolver = rootOfTrustResolver
         return self
@@ -100,6 +101,7 @@ public class VerifiedIdClientBuilder {
         return self
     }
     
+    /// Optional method to add a custom Verified Id Extension to the VerifiedIdClient.
     public func with(verifiedIdExtension: VerifiedIdExtendable) -> VerifiedIdClientBuilder
     {
         self.extensions.append(verifiedIdExtension)

--- a/WalletLibrary/WalletLibraryTests/Mocks/RootOfTrust/MockRootOfTrustResolver.swift
+++ b/WalletLibrary/WalletLibraryTests/Mocks/RootOfTrust/MockRootOfTrustResolver.swift
@@ -5,7 +5,7 @@
 
 @testable import WalletLibrary
 
-struct MockRootOfTrustResolver: RootOfTrustResolving
+struct MockRootOfTrustResolver: RootOfTrustResolver
 {
     enum ExpectedError: Error
     {
@@ -19,7 +19,7 @@ struct MockRootOfTrustResolver: RootOfTrustResolving
         self.shouldThrowError = shouldThrowError
     }
     
-    func resolve(using identifier: IdentifierDocument) async throws -> RootOfTrust
+    func resolve(from identifier: IdentifierMetadata) async throws -> RootOfTrust
     {
         if shouldThrowError
         {


### PR DESCRIPTION
**Problem:**
Developers of the SDK might want to inject their own Root of Trust Resolver into the Verified ID Client.


**Solution:**
Create an protocol called `RootOfTrustResolver` that takes in an abstract `IdentifierMetadata` and returns the `RootOfTrust` during issuance and presentation flows.


**Validation:**
Flow works E2E. All unit tests pass.


**Type of change:**
- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.