### PR TITLE
Migrate identifity DB to resolve internal conflict and make Root Of Trust init public

### DIFF
--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/Resources/coreData/CoreDataManager.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/Resources/coreData/CoreDataManager.swift
@@ -16,8 +16,8 @@ class CoreDataManager {
     
     private struct Constants {
         static let bundleId = "com.microsoft.VCUseCase"
-        static let model = "VerifiableCredentialDataModel"
-        static let identifierModel = "IdentifierModel"
+        static let model = "VerifiedIdDataModel"
+        static let identifierModel = "IdentifierDataModel"
         static let extensionType = "momd"
         static let sqliteDescription = "sqlite"
     }
@@ -36,19 +36,19 @@ class CoreDataManager {
     }
     
     func saveIdentifier(longformDid: String,
-                               signingKeyId: UUID,
-                               recoveryKeyId: UUID,
-                               updateKeyId: UUID,
-                               alias: String,
-                               signingKeyAlias: String? = nil,
-                               recoveryKeyAlias: String? = nil,
-                               updateKeyAlias: String? = nil) throws {
+                        signingKeyId: UUID,
+                        recoveryKeyId: UUID,
+                        updateKeyId: UUID,
+                        alias: String,
+                        signingKeyAlias: String? = nil,
+                        recoveryKeyAlias: String? = nil,
+                        updateKeyAlias: String? = nil) throws {
         guard let persistentContainer = persistentContainer else {
             throw CoreDataManagerError.persistentStoreNotLoaded
         }
         
         let model = NSEntityDescription.insertNewObject(forEntityName: Constants.identifierModel,
-                                                        into: persistentContainer.viewContext) as! IdentifierModel
+                                                        into: persistentContainer.viewContext) as! IdentifierDataModel
         
         model.did = longformDid
         model.recoveryKeyId = recoveryKeyId
@@ -62,12 +62,12 @@ class CoreDataManager {
         try persistentContainer.viewContext.save()
     }
     
-    func fetchIdentifiers() throws -> [IdentifierModel] {
+    public func fetchIdentifiers() throws -> [IdentifierDataModel] {
         guard let persistentContainer = persistentContainer else {
             throw CoreDataManagerError.persistentStoreNotLoaded
         }
         
-        let fetchRequest: NSFetchRequest<IdentifierModel> = IdentifierModel.fetchRequest()
+        let fetchRequest: NSFetchRequest<IdentifierDataModel> = IdentifierDataModel.fetchRequest()
         return try persistentContainer.viewContext.fetch(fetchRequest)
     }
     
@@ -76,7 +76,7 @@ class CoreDataManager {
             throw CoreDataManagerError.persistentStoreNotLoaded
         }
         
-        let fetchRequest: NSFetchRequest<IdentifierModel> = IdentifierModel.fetchRequest()
+        let fetchRequest: NSFetchRequest<IdentifierDataModel> = IdentifierDataModel.fetchRequest()
         let models = try persistentContainer.viewContext.fetch(fetchRequest)
         
         for model in models {
@@ -86,7 +86,7 @@ class CoreDataManager {
         try persistentContainer.viewContext.save()
     }
     
-    func deleteIdentifer(_ model:IdentifierModel) {
+    public func deleteIdentifer(_ model:IdentifierDataModel) {
         persistentContainer?.viewContext.delete(model)
     }
     
@@ -100,6 +100,12 @@ class CoreDataManager {
         }
         
         let container = NSPersistentContainer(name: Constants.model, managedObjectModel: managedObjectModel)
+        
+        let description = NSPersistentStoreDescription()
+        description.shouldMigrateStoreAutomatically = true
+        description.shouldInferMappingModelAutomatically = true
+        container.persistentStoreDescriptions.append(description)
+        container.viewContext.mergePolicy = NSMergePolicy.overwrite
         
         container.loadPersistentStores {
             [weak self] (storeDescription, error) in

--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/Resources/coreData/IdentifierDatabase.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/Resources/coreData/IdentifierDatabase.swift
@@ -53,7 +53,7 @@ struct IdentifierDatabase {
         
         let identifierModels = try coreDataManager.fetchIdentifiers()
         
-        var identifierModel: IdentifierModel? = nil
+        var identifierModel: IdentifierDataModel? = nil
         
         for identifier in identifierModels {
             if identifier.alias == alias {
@@ -72,7 +72,7 @@ struct IdentifierDatabase {
         
         let identifierModels = try coreDataManager.fetchIdentifiers()
         
-        var identifierModel: IdentifierModel? = nil
+        var identifierModel: IdentifierDataModel? = nil
         
         for identifier in identifierModels {
             if identifier.did == did {
@@ -121,7 +121,7 @@ struct IdentifierDatabase {
         try self.saveIdentifier(identifier: identifier)
     }
     
-    private func createIdentifier(fromIdentifierModel model: IdentifierModel) throws -> Identifier {
+    private func createIdentifier(fromIdentifierModel model: IdentifierDataModel) throws -> Identifier {
         
         guard let longFormDid = model.did,
             let alias = model.alias else {

--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/Resources/coreData/VerifiedIdDataModel.xcdatamodeld/.xccurrentversion
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/Resources/coreData/VerifiedIdDataModel.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>Identifier 2.0.xcdatamodel</string>
+</dict>
+</plist>

--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/Resources/coreData/VerifiedIdDataModel.xcdatamodeld/Identifier 2.0.xcdatamodel/contents
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/Resources/coreData/VerifiedIdDataModel.xcdatamodeld/Identifier 2.0.xcdatamodel/contents
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21E258" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <entity name="IdentifierModel" representedClassName="IdentifierModel" syncable="YES" codeGenerationType="class">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22F82" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="IdentifierDataModel" representedClassName="IdentifierDataModel" elementID="IdentifierModel" syncable="YES" codeGenerationType="class">
         <attribute name="alias" optional="YES" attributeType="String"/>
         <attribute name="did" optional="YES" attributeType="String"/>
         <attribute name="recoveryKeyAlias" optional="YES" attributeType="String"/>
@@ -10,7 +10,4 @@
         <attribute name="updateKeyAlias" optional="YES" attributeType="String"/>
         <attribute name="updateKeyId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>
-    <elements>
-        <element name="IdentifierModel" positionX="-63" positionY="-18" width="128" height="149"/>
-    </elements>
 </model>

--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/Resources/coreData/VerifiedIdDataModel.xcdatamodeld/Identifier.xcdatamodel/contents
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/Resources/coreData/VerifiedIdDataModel.xcdatamodeld/Identifier.xcdatamodel/contents
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22F82" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="IdentifierModel" representedClassName="IdentifierModel" syncable="YES" codeGenerationType="class">
+        <attribute name="alias" optional="YES" attributeType="String"/>
+        <attribute name="did" optional="YES" attributeType="String"/>
+        <attribute name="recoveryKeyAlias" optional="YES" attributeType="String"/>
+        <attribute name="recoveryKeyId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="signingKeyAlias" optional="YES" attributeType="String"/>
+        <attribute name="signingKeyId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="updateKeyAlias" optional="YES" attributeType="String"/>
+        <attribute name="updateKeyId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+    </entity>
+</model>

--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -83,7 +83,6 @@
 		5552D28629EF340200B40302 /* IdentifierService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5552D26F29EF335500B40302 /* IdentifierService.swift */; };
 		5552D28829EF340900B40302 /* difwordlist.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5552D27229EF335500B40302 /* difwordlist.txt */; };
 		5552D28929EF343000B40302 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5552D27529EF335500B40302 /* CoreDataManager.swift */; };
-		5552D28A29EF343400B40302 /* VerifiableCredentialDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 5552D27629EF335500B40302 /* VerifiableCredentialDataModel.xcdatamodeld */; };
 		5552D28B29EF343700B40302 /* IdentifierDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5552D27829EF335500B40302 /* IdentifierDatabase.swift */; };
 		5552D39E29EF481100B40302 /* ResponseMappings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5552D30029EF47EC00B40302 /* ResponseMappings.swift */; };
 		5552D39F29EF481600B40302 /* ExchangeRequestClaims.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5552D30429EF47EC00B40302 /* ExchangeRequestClaims.swift */; };
@@ -517,6 +516,7 @@
 		55BA2DDB29CDFA6100BB8207 /* VerifiedIdEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BA2DD929CDFA6100BB8207 /* VerifiedIdEncoderTests.swift */; };
 		55C422C82CD1745B0013F44F /* IdentifierFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55C422C72CD1745B0013F44F /* IdentifierFactoryTests.swift */; };
 		55C422CA2CD17A920013F44F /* MockCryptoRequirement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55C422C92CD17A920013F44F /* MockCryptoRequirement.swift */; };
+		55C423322CD52D6D0013F44F /* VerifiedIdDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 55C4232F2CD52D6C0013F44F /* VerifiedIdDataModel.xcdatamodeld */; };
 		55DECBD029B922D200D5C802 /* MockPresentationResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DECBCF29B922D200D5C802 /* MockPresentationResponder.swift */; };
 		55DECBE729B92E3900D5C802 /* RawPresentationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DECBE629B92E3900D5C802 /* RawPresentationResponse.swift */; };
 		55DECBE929B934B900D5C802 /* IssuanceRequestContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DECBE829B934B900D5C802 /* IssuanceRequestContent.swift */; };
@@ -675,7 +675,6 @@
 		5552D26F29EF335500B40302 /* IdentifierService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierService.swift; sourceTree = "<group>"; };
 		5552D27229EF335500B40302 /* difwordlist.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = difwordlist.txt; sourceTree = "<group>"; };
 		5552D27529EF335500B40302 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
-		5552D27729EF335500B40302 /* Identifier.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Identifier.xcdatamodel; sourceTree = "<group>"; };
 		5552D27829EF335500B40302 /* IdentifierDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierDatabase.swift; sourceTree = "<group>"; };
 		5552D27929EF335500B40302 /* LinkedDomainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedDomainService.swift; sourceTree = "<group>"; };
 		5552D27A29EF335600B40302 /* ServicesConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicesConstants.swift; sourceTree = "<group>"; };
@@ -1117,6 +1116,8 @@
 		55BA2DD929CDFA6100BB8207 /* VerifiedIdEncoderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerifiedIdEncoderTests.swift; sourceTree = "<group>"; };
 		55C422C72CD1745B0013F44F /* IdentifierFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierFactoryTests.swift; sourceTree = "<group>"; };
 		55C422C92CD17A920013F44F /* MockCryptoRequirement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCryptoRequirement.swift; sourceTree = "<group>"; };
+		55C423302CD52D6C0013F44F /* Identifier 2.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Identifier 2.0.xcdatamodel"; sourceTree = "<group>"; };
+		55C423312CD52D6C0013F44F /* Identifier.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Identifier.xcdatamodel; sourceTree = "<group>"; };
 		55DECBCF29B922D200D5C802 /* MockPresentationResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPresentationResponder.swift; sourceTree = "<group>"; };
 		55DECBE629B92E3900D5C802 /* RawPresentationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawPresentationResponse.swift; sourceTree = "<group>"; };
 		55DECBE829B934B900D5C802 /* IssuanceRequestContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuanceRequestContent.swift; sourceTree = "<group>"; };
@@ -1572,8 +1573,8 @@
 		5552D27429EF335500B40302 /* coreData */ = {
 			isa = PBXGroup;
 			children = (
+				55C4232F2CD52D6C0013F44F /* VerifiedIdDataModel.xcdatamodeld */,
 				5552D27529EF335500B40302 /* CoreDataManager.swift */,
-				5552D27629EF335500B40302 /* VerifiableCredentialDataModel.xcdatamodeld */,
 				5552D27829EF335500B40302 /* IdentifierDatabase.swift */,
 			);
 			path = coreData;
@@ -2554,6 +2555,7 @@
 			isa = PBXGroup;
 			children = (
 				555FB1F52B75654D00EE14BD /* Resolvers */,
+				5534E5B42948FEB5005D0765 /* RootOfTrust.swift */,
 			);
 			path = RootOfTrust;
 			sourceTree = "<group>";
@@ -3078,7 +3080,6 @@
 				550A9156299310D40014D030 /* Processors */,
 				550A916D299310D40014D030 /* Resolvers */,
 				55E336CF293FA6D900CD2ED7 /* Requirements */,
-				5534E5B42948FEB5005D0765 /* RootOfTrust.swift */,
 				55E2F07E29955A3B0008010D /* PresentationRequestContent.swift */,
 				55DECBE829B934B900D5C802 /* IssuanceRequestContent.swift */,
 				A497435A2B8EA367004851C2 /* VerifiedIdPartialRequest.swift */,
@@ -3684,7 +3685,6 @@
 				5552D3E329EF48C700B40302 /* ServiceDescriptor.swift in Sources */,
 				55E2F08A299576350008010D /* PresentationDefinition+Mappable.swift in Sources */,
 				5552D39F29EF481600B40302 /* ExchangeRequestClaims.swift in Sources */,
-				5552D28A29EF343400B40302 /* VerifiableCredentialDataModel.xcdatamodeld in Sources */,
 				553CC09D29A97181005A5FD6 /* IssuanceResponseContaining.swift in Sources */,
 				55A0DA182A74466700BC178E /* PresentationExchangePattern.swift in Sources */,
 				55DECBE929B934B900D5C802 /* IssuanceRequestContent.swift in Sources */,
@@ -3698,6 +3698,7 @@
 				5552D48A29EF4AAB00B40302 /* JwsDecoder.swift in Sources */,
 				55A0DA1C2A745E4200BC178E /* Dictionary+ValueExtraction.swift in Sources */,
 				55E336D4293FA75300CD2ED7 /* VerifiedId.swift in Sources */,
+				55C423322CD52D6D0013F44F /* VerifiedIdDataModel.xcdatamodeld in Sources */,
 				55BA2DD329CDFA1A00BB8207 /* EncodedVerifiedId.swift in Sources */,
 				55A638692BB36C7E00BE2AF2 /* TokenBuilderFactory.swift in Sources */,
 				5552D28B29EF343700B40302 /* IdentifierDatabase.swift in Sources */,
@@ -4340,13 +4341,15 @@
 /* End XCConfigurationList section */
 
 /* Begin XCVersionGroup section */
-		5552D27629EF335500B40302 /* VerifiableCredentialDataModel.xcdatamodeld */ = {
+		55C4232F2CD52D6C0013F44F /* VerifiedIdDataModel.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
-				5552D27729EF335500B40302 /* Identifier.xcdatamodel */,
+				55C423302CD52D6C0013F44F /* Identifier 2.0.xcdatamodel */,
+				55C423312CD52D6C0013F44F /* Identifier.xcdatamodel */,
 			);
-			currentVersion = 5552D27729EF335500B40302 /* Identifier.xcdatamodel */;
-			path = VerifiableCredentialDataModel.xcdatamodeld;
+			currentVersion = 55C423302CD52D6C0013F44F /* Identifier 2.0.xcdatamodel */;
+			name = VerifiedIdDataModel.xcdatamodeld;
+			path = "/Users/sydneymorton/Projects/AD-DID-Mobile-Testing-iOS/Submodules/entra-verifiedid-wallet-library-ios/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/Resources/coreData/VerifiedIdDataModel.xcdatamodeld";
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;
 		};

--- a/WalletLibrary/WalletLibrary/RootOfTrust/RootOfTrust.swift
+++ b/WalletLibrary/WalletLibrary/RootOfTrust/RootOfTrust.swift
@@ -6,12 +6,18 @@
 /**
  * Root of Trust such as Linked Domain Verified for the request.
  */
-public struct RootOfTrust: Equatable {
-    
+public struct RootOfTrust: Equatable 
+{
     /// Whether root of trust is verified or not (for example, if the linked domain check succeeded.
     public let verified: Bool
     
     /// The source of the root of trust (could be the well-known endpoint url or a hub perhaps).
     public let source: String?
     
+    public init(verified: Bool, 
+                source: String?)
+    {
+        self.verified = verified
+        self.source = source
+    }
 }


### PR DESCRIPTION
**Problem:**
- Our internal release has a conflict with the Identifier Core Data entity name with the old VC SDK.
- Root Of Trust init was not public so unable to inject a root of trust resolver into library.


**Solution:**
- Migrate identifity DB to resolve internal conflict.
- Make init public.


**Validation:**
- All unit tests pass.


**Type of change:**
- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.