### PR TITLE
Add preview feature flag for FIPS compliance and add to VerifiedIdBuilder

### DIFF
--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCCrypto/VCCrypto/KeyManagementOperations.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCCrypto/VCCrypto/KeyManagementOperations.swift
@@ -10,7 +10,7 @@ struct KeyManagementOperations: KeyManagementOperating {
     
     private let sdkConfiguration: VCSDKConfigurable
     
-    init(sdkConfiguration: VCSDKConfigurable) {
+    init(sdkConfiguration: VCSDKConfigurable = VCSDKConfiguration.sharedInstance) {
         self.init(secretStore: KeychainSecretStore(), sdkConfiguration: sdkConfiguration)
     }
     

--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -429,6 +429,7 @@
 		559765882CDD6FA300CE6504 /* MockHolderIdentifierBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 559765872CDD6FA300CE6504 /* MockHolderIdentifierBuilder.swift */; };
 		5597658B2CDD704900CE6504 /* MockHolderIdentifierStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5597658A2CDD704900CE6504 /* MockHolderIdentifierStorage.swift */; };
 		5597658E2CDD885900CE6504 /* HolderIdentifierStoredProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5597658D2CDD885900CE6504 /* HolderIdentifierStoredProperties.swift */; };
+		5597662C2CDEC74300CE6504 /* MockIdentifierRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5597662B2CDEC74300CE6504 /* MockIdentifierRepository.swift */; };
 		5598CFCD2AAF8DD600EBDE87 /* RequestedClaimsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5598CFCC2AAF8DD600EBDE87 /* RequestedClaimsTests.swift */; };
 		5598CFD22AAF8E7500EBDE87 /* PresentationResponseContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5598CFD12AAF8E7500EBDE87 /* PresentationResponseContainerTests.swift */; };
 		5598CFD42AAF931E00EBDE87 /* PresentationResponseEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5598CFD32AAF931E00EBDE87 /* PresentationResponseEncoderTests.swift */; };
@@ -1040,6 +1041,7 @@
 		559765872CDD6FA300CE6504 /* MockHolderIdentifierBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHolderIdentifierBuilder.swift; sourceTree = "<group>"; };
 		5597658A2CDD704900CE6504 /* MockHolderIdentifierStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHolderIdentifierStorage.swift; sourceTree = "<group>"; };
 		5597658D2CDD885900CE6504 /* HolderIdentifierStoredProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HolderIdentifierStoredProperties.swift; sourceTree = "<group>"; };
+		5597662B2CDEC74300CE6504 /* MockIdentifierRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockIdentifierRepository.swift; sourceTree = "<group>"; };
 		5598CFCC2AAF8DD600EBDE87 /* RequestedClaimsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestedClaimsTests.swift; sourceTree = "<group>"; };
 		5598CFD12AAF8E7500EBDE87 /* PresentationResponseContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationResponseContainerTests.swift; sourceTree = "<group>"; };
 		5598CFD32AAF931E00EBDE87 /* PresentationResponseEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationResponseEncoderTests.swift; sourceTree = "<group>"; };
@@ -2751,6 +2753,14 @@
 			path = Entities;
 			sourceTree = "<group>";
 		};
+		5597662A2CDEC73200CE6504 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				5597662B2CDEC74300CE6504 /* MockIdentifierRepository.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
 		5598CFCA2AAF8DBC00EBDE87 /* oidc */ = {
 			isa = PBXGroup;
 			children = (
@@ -2979,6 +2989,7 @@
 		55A81C0A2991BF6C002C259A /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				5597662A2CDEC73200CE6504 /* Repositories */,
 				55A268AA2CC1BDEB00A8EA9C /* Identifier */,
 				555FB2102B759FA700EE14BD /* RootOfTrust */,
 				55265B0D2B71908300BAD6A2 /* Networking */,
@@ -3979,6 +3990,7 @@
 				5552D82D29F2E25900B40302 /* OIDCClaimsTests.swift in Sources */,
 				555FB20F2B75874A00EE14BD /* SignedCredentialMetadataProcessorTests.swift in Sources */,
 				55DECC4129BFEDE400D5C802 /* VerifiedIdRequirementTests.swift in Sources */,
+				5597662C2CDEC74300CE6504 /* MockIdentifierRepository.swift in Sources */,
 				557539E02BBDF27C009E1257 /* VerifiableCredentialSerializerTests.swift in Sources */,
 				5552D7D729F2E0AA00B40302 /* Secp256k1Tests.swift in Sources */,
 				559BD4F8299EED5700BD61AC /* MockRawManifest.swift in Sources */,

--- a/WalletLibrary/WalletLibrary/Errors/VerifiedIdErrors.swift
+++ b/WalletLibrary/WalletLibrary/Errors/VerifiedIdErrors.swift
@@ -104,7 +104,7 @@ public class UnspecifiedVerifiedIdError: VerifiedIdError {
     
     init(error: Error, correlationId: String?) {
         self.error = error
-        super.init(message: "Unspecified Error.",
+        super.init(message: String(describing: error),
                    code: VerifiedIdErrors.ErrorCode.UnspecifiedError,
                    correlationId: correlationId)
     }

--- a/WalletLibrary/WalletLibrary/Identifier/Builders/KeychainHolderIdentifierBuilder.swift
+++ b/WalletLibrary/WalletLibrary/Identifier/Builders/KeychainHolderIdentifierBuilder.swift
@@ -18,7 +18,8 @@ class KeychainHolderIdentifierBuilder: HolderIdentifierBuilder
     /// An instance of `DIDBuilder` used for creating decentralized identifiers (DIDs).
     private let didBuilder: DIDBuilder
     
-    init(keyManagementOperations: KeyManagementOperating, cryptoOperations: CryptoOperating) 
+    init(keyManagementOperations: KeyManagementOperating = KeyManagementOperations(),
+         cryptoOperations: CryptoOperating = CryptoOperations())
     {
         self.keyManagementOperations = keyManagementOperations
         self.cryptoOperations = cryptoOperations

--- a/WalletLibrary/WalletLibrary/Identifier/KeychainIdentifier.swift
+++ b/WalletLibrary/WalletLibrary/Identifier/KeychainIdentifier.swift
@@ -66,10 +66,10 @@ class KeychainIdentifier: HolderIdentifier, JWKRepresentable, Mappable
         let publicKey = try cryptoOperations.getPublicKey(fromSecret: keyReferenceSecret,
                                                           algorithm: algorithm)
         
-        guard let key = publicKey as? EllipticCurvePublicKey else
+        guard let key = publicKey as? Secp256k1PublicKey else
         {
-            // TODO: support other key types for FIPS compliance.
-            throw VerifiedIdErrors.MalformedInput(message: "Unable to case public to EllipticCurvePublicKey.").error
+            // Will fix in JWK Refactor PR.
+            throw VerifiedIdErrors.MalformedInput(message: "Unable to cast to Secp256K1PublicKey.").error
         }
         
         return ECPublicJwk(withPublicKey: key, 

--- a/WalletLibrary/WalletLibrary/Identifier/KeychainIdentifier.swift
+++ b/WalletLibrary/WalletLibrary/Identifier/KeychainIdentifier.swift
@@ -66,10 +66,10 @@ class KeychainIdentifier: HolderIdentifier, JWKRepresentable, Mappable
         let publicKey = try cryptoOperations.getPublicKey(fromSecret: keyReferenceSecret,
                                                           algorithm: algorithm)
         
-        guard let key = publicKey as? Secp256k1PublicKey else 
+        guard let key = publicKey as? EllipticCurvePublicKey else
         {
             // TODO: support other key types for FIPS compliance.
-            throw VerifiedIdErrors.MalformedInput(message: "Unable to case public key to Secp256k1.").error
+            throw VerifiedIdErrors.MalformedInput(message: "Unable to case public to EllipticCurvePublicKey.").error
         }
         
         return ECPublicJwk(withPublicKey: key, 

--- a/WalletLibrary/WalletLibrary/Identifier/KeychainIdentifier.swift
+++ b/WalletLibrary/WalletLibrary/Identifier/KeychainIdentifier.swift
@@ -66,10 +66,10 @@ class KeychainIdentifier: HolderIdentifier, JWKRepresentable, Mappable
         let publicKey = try cryptoOperations.getPublicKey(fromSecret: keyReferenceSecret,
                                                           algorithm: algorithm)
         
-        guard let key = publicKey as? Secp256k1PublicKey else
+        guard let key = publicKey as? Secp256k1PublicKey else 
         {
-            // Will fix in JWK Refactor PR.
-            throw VerifiedIdErrors.MalformedInput(message: "Unable to cast to Secp256K1PublicKey.").error
+            // TODO: support other key types for FIPS compliance.
+            throw VerifiedIdErrors.MalformedInput(message: "Unable to case public key to Secp256k1.").error
         }
         
         return ECPublicJwk(withPublicKey: key, 

--- a/WalletLibrary/WalletLibrary/Repositories/IdentifierRepository.swift
+++ b/WalletLibrary/WalletLibrary/Repositories/IdentifierRepository.swift
@@ -15,8 +15,8 @@ class IdentifierRepository: HolderIdentifierRepository
     /// An object responsible for storing and retrieving holder identifiers.
     private let storage: HolderIdentifierStorage
     
-    init(builder: HolderIdentifierBuilder,
-         storage: HolderIdentifierStorage)
+    init(builder: HolderIdentifierBuilder = KeychainHolderIdentifierBuilder(),
+         storage: HolderIdentifierStorage = CoreDataManager.sharedInstance)
     {
         self.builder = builder
         self.storage = storage

--- a/WalletLibrary/WalletLibrary/Utilities/PreviewFeatureFlags.swift
+++ b/WalletLibrary/WalletLibrary/Utilities/PreviewFeatureFlags.swift
@@ -14,6 +14,9 @@ public struct PreviewFeatureFlags
     /// A preview feature for Pre Auth support from the OpenID4VCI protocol.
     public static let OpenID4VCIPreAuth = "OpenID4VCIPreAuth"
     
+    /// A preview feature for FIPS Complaint key support for holder.
+    public static let FIPSCompliantIdentifier = "FIPSCompliantIdentifier"
+    
     /// A preview feature to support building Presentation Exchange Response through serialization
     /// instead of using the old VC SDK. Default on now.
     /// public static let PresentationExchangeSerializationSupport = "PresentationExchangeSerializationSupport"
@@ -25,6 +28,7 @@ public struct PreviewFeatureFlags
     private var supportedPreviewFeatures: [String: Bool] = [
         OpenID4VCIAccessToken: false,
         OpenID4VCIPreAuth: false,
+        FIPSCompliantIdentifier: false
     ]
     
     init(previewFeatureFlags: [String] = [])

--- a/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
@@ -106,7 +106,7 @@ public class VerifiedIdClientBuilder
         }
         catch
         {
-            logger.logError(message: "Unable to get main Holder Identifier from repository.")
+            logger.logError(message: "Unable to get main Holder Identifier from repository, \(String(describing: error))")
             return nil
         }
     }

--- a/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
@@ -45,17 +45,7 @@ public class VerifiedIdClientBuilder
                                                               logger: logger,
                                                               correlationHeader: correlationHeader)
         
-        /// Append default identifier to the end of the list of Identifiers.
-        var allIdentifiers = identifiers
-        if let defaultIdentifier = try? VerifiableCredentialSDK.identifierService.fetchOrCreateMasterIdentifier(),
-           let holderIdentifier = try? defaultIdentifier.toHolderIdentifier(cryptoOperations: CryptoOperations())
-        {
-            allIdentifiers.append(holderIdentifier)
-        }
-        else
-        {
-            logger.logError(message: "Unable to load default Identifier.")
-        }
+        let identifiers = getAllIdentifiers(previewFeatureFlags: previewFeatureFlags)
         
         let configuration = LibraryConfiguration(logger: logger,
                                                  mapper: Mapper(),
@@ -63,7 +53,7 @@ public class VerifiedIdClientBuilder
                                                  verifiedIdDecoder: VerifiedIdDecoder(),
                                                  verifiedIdEncoder: VerifiedIdEncoder(),
                                                  previewFeatureFlags: previewFeatureFlags,
-                                                 identifiers: allIdentifiers)
+                                                 identifiers: identifiers)
         
         registerSupportedResolvers(with: configuration)
         registerSupportedRequestProcessors(with: configuration)
@@ -74,6 +64,41 @@ public class VerifiedIdClientBuilder
         return VerifiedIdClient(requestResolverFactory: requestResolverFactory,
                                 requestHandlerFactory: requestHandlerFactory,
                                 configuration: configuration)
+    }
+    
+    private func getAllIdentifiers(previewFeatureFlags: PreviewFeatureFlags) -> [HolderIdentifier]
+    {
+        if previewFeatureFlags.isPreviewFeatureSupported(PreviewFeatureFlags.FIPSCompliantIdentifier),
+           let holderIdentifier = getMainHolderIdentifier()
+        {
+            identifiers.append(holderIdentifier)
+        }
+        else if let defaultIdentifier = try? VerifiableCredentialSDK.identifierService.fetchOrCreateMasterIdentifier(),
+                let holderIdentifier = try? defaultIdentifier.toHolderIdentifier(cryptoOperations: CryptoOperations())
+        {
+            identifiers.append(holderIdentifier)
+        }
+        else
+        {
+            logger.logError(message: "Unable to load default Identifiers.")
+        }
+        
+        return identifiers
+    }
+    
+    private func getMainHolderIdentifier() -> HolderIdentifier?
+    {
+        let identifierRepository = IdentifierRepository()
+        do
+        {
+            let holderIdentifier = try identifierRepository.getMainHolderIdentifier()
+            return holderIdentifier
+        }
+        catch
+        {
+            print(error)
+            return nil
+        }
     }
     
     /// Optional method to add new Identifiers to Wallet Library..

--- a/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
@@ -28,8 +28,19 @@ public class VerifiedIdClientBuilder
     
     private var identifiers: [HolderIdentifier] = []
     
-    public init() {
+    private let identifierRepository: HolderIdentifierRepository
+    
+    public init() 
+    {
         logger = WalletLibraryLogger()
+        self.identifierRepository = IdentifierRepository()
+    }
+    
+    /// Internal init to help with testing.
+    init(identifierRepository: HolderIdentifierRepository)
+    {
+        self.logger = WalletLibraryLogger()
+        self.identifierRepository = identifierRepository
     }
 
     /// Builds the VerifiedIdClient with the set configuration from the builder.
@@ -88,7 +99,6 @@ public class VerifiedIdClientBuilder
     
     private func getMainHolderIdentifier() -> HolderIdentifier?
     {
-        let identifierRepository = IdentifierRepository()
         do
         {
             let holderIdentifier = try identifierRepository.getMainHolderIdentifier()
@@ -96,7 +106,7 @@ public class VerifiedIdClientBuilder
         }
         catch
         {
-            print(error)
+            logger.logError(message: "Unable to get main Holder Identifier from repository.")
             return nil
         }
     }

--- a/WalletLibrary/WalletLibraryTests/Mocks/Repositories/MockIdentifierRepository.swift
+++ b/WalletLibrary/WalletLibraryTests/Mocks/Repositories/MockIdentifierRepository.swift
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+@testable import WalletLibrary
+
+struct MockIdentifierRepository: HolderIdentifierRepository
+{
+    private let expectedIdentifier: HolderIdentifier?
+    
+    private let expectedErrorThrown: Error?
+    
+    init(expectedIdentifier: HolderIdentifier? = nil, expectedErrorThrown: Error? = nil)
+    {
+        self.expectedIdentifier = expectedIdentifier
+        self.expectedErrorThrown = expectedErrorThrown
+    }
+    
+    func getMainHolderIdentifier() throws -> HolderIdentifier
+    {
+        if let error = expectedErrorThrown
+        {
+            throw error
+        }
+        else
+        {
+            return expectedIdentifier ?? MockHolderIdentifier()
+        }
+    }
+}

--- a/WalletLibrary/WalletLibraryTests/VerifiedIdClientBuilderTests.swift
+++ b/WalletLibrary/WalletLibraryTests/VerifiedIdClientBuilderTests.swift
@@ -355,4 +355,30 @@ class VerifiedIdClientBuilderTests: XCTestCase {
         XCTAssertEqual(actualResult.configuration.identifierFactory.identifiers[0] as? MockHolderIdentifier, mockHolder1)
         XCTAssertEqual(actualResult.configuration.identifierFactory.identifiers[1] as? MockHolderIdentifier, mockHolder2)
     }
+    
+    func testBuild_WithFIPSCompliantPreviewFeatureFlag_ReturnsVerifiedIdClient() throws
+    {
+        // Arrange
+        let mockHolderIdentifier = MockHolderIdentifier(id: "mockHolder1")
+        let mockRepository = MockIdentifierRepository(expectedIdentifier: mockHolderIdentifier)
+        let builder = VerifiedIdClientBuilder(identifierRepository: mockRepository)
+        
+        // Act
+        let actualResult = builder
+            .with(previewFeatureFlags: [PreviewFeatureFlags.FIPSCompliantIdentifier])
+            .build()
+        
+        // Assert
+        XCTAssertEqual(actualResult.requestHandlerFactory.requestHandlers.count, 2)
+        XCTAssert(actualResult.requestHandlerFactory.requestHandlers.contains { $0 is OpenIdRequestProcessor })
+        XCTAssert(actualResult.requestHandlerFactory.requestHandlers.contains { $0 is OpenId4VCIProcessor })
+        XCTAssertEqual(actualResult.requestResolverFactory.resolvers.count, 1)
+        XCTAssert(actualResult.requestResolverFactory.resolvers.contains { $0 is OpenIdURLRequestResolver })
+        XCTAssert(actualResult.configuration.logger.consumers.isEmpty)
+        XCTAssert(actualResult.configuration.logger.consumers.isEmpty)
+        XCTAssert(actualResult.configuration.verifiedIdDecoder is VerifiedIdDecoder)
+        XCTAssert(actualResult.configuration.verifiedIdEncoder is VerifiedIdEncoder)
+        XCTAssertEqual(actualResult.configuration.identifierFactory.identifiers[0] as? MockHolderIdentifier,
+                       mockHolderIdentifier)
+    }
 }

--- a/WalletLibrary/WalletLibraryTests/VerifiedIdClientBuilderTests.swift
+++ b/WalletLibrary/WalletLibraryTests/VerifiedIdClientBuilderTests.swift
@@ -378,6 +378,7 @@ class VerifiedIdClientBuilderTests: XCTestCase {
         XCTAssert(actualResult.configuration.logger.consumers.isEmpty)
         XCTAssert(actualResult.configuration.verifiedIdDecoder is VerifiedIdDecoder)
         XCTAssert(actualResult.configuration.verifiedIdEncoder is VerifiedIdEncoder)
+        XCTAssertEqual(actualResult.configuration.identifierFactory.identifiers.count, 1)
         XCTAssertEqual(actualResult.configuration.identifierFactory.identifiers[0] as? MockHolderIdentifier,
                        mockHolderIdentifier)
     }


### PR DESCRIPTION
**Problem:**
Need to create preview flag for using FIPS compliant HolderIdentifier in library.


**Solution:**
Add new flag and use flag to go through new Identifier path is turned on.


**Validation:**
All unit tests pass as expected.


**Type of change:**
- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.