### PR TITLE
Potential fix for iOS key issues on device transfer

### DIFF
--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCEntities/VCEntitiesTests/validators/PresentationRequestValidatorTests.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCEntities/VCEntitiesTests/validators/PresentationRequestValidatorTests.swift
@@ -165,7 +165,7 @@ class PresentationRequestValidatorTests: XCTestCase {
                                   clientPurpose: "clientPurpose",
                                   logoURI: "logoURI",
                                   subjectIdentifierTypesSupported: [expectedSubjectIdentifierType],
-                                  vpFormats: SupportedVerifiablePresentationFormats(jwtVP: supportedAlgorithmsForVP, jwtVC: supportedAlgorithmsForVC))
+                                  vpFormats: SupportedVerifiablePresentationFormats(jwtVP: supportedAlgorithmsForVP, jwtVC: supportedAlgorithmsForVC), scenario: nil)
     }
     
 }

--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/Resources/coreData/CoreDataManager.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/Resources/coreData/CoreDataManager.swift
@@ -67,7 +67,7 @@ class CoreDataManager: HolderIdentifierStorage
         return try persistentContainerContext.fetch(fetchRequest)
     }
     
-    /// Deletes teh Holder Identifier from the persistent storage.
+    /// Deletes the Holder Identifier from the persistent storage.
     func deleteHolderIdentifier(identifier: any HolderIdentifierStoredProperties) throws {
         guard let persistentContainerContext = persistentContainer?.viewContext else
         {

--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/Resources/coreData/CoreDataManager.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCServices/VCServices/Resources/coreData/CoreDataManager.swift
@@ -67,6 +67,22 @@ class CoreDataManager: HolderIdentifierStorage
         return try persistentContainerContext.fetch(fetchRequest)
     }
     
+    /// Deletes teh Holder Identifier from the persistent storage.
+    func deleteHolderIdentifier(identifier: any HolderIdentifierStoredProperties) throws {
+        guard let persistentContainerContext = persistentContainer?.viewContext else
+        {
+            throw CoreDataManagerError.persistentStoreNotLoaded
+        }
+        
+        
+        let storedIdentifier = HolderIdentifierDataModel(holderIdentifier: identifier,
+                                                         context: persistentContainerContext)
+        
+        persistentContainerContext.delete(storedIdentifier)
+        
+        try persistentContainerContext.save()
+    }
+    
     func saveIdentifier(longformDid: String,
                         signingKeyId: UUID,
                         recoveryKeyId: UUID,

--- a/WalletLibrary/WalletLibrary/Protocols/Repositories/HolderIdentifierRepository.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Repositories/HolderIdentifierRepository.swift
@@ -13,4 +13,8 @@ protocol HolderIdentifierRepository
     /// - Throws: An error if there is an issue retrieving the `HolderIdentifier`.
     /// - Returns: The main `HolderIdentifier` instance.
     func getMainHolderIdentifier() throws -> HolderIdentifier
+    
+    /// Prunes the repository of `HolderIdentifier`s not found in the keychain.
+    /// - Throws: unexpected keychain/storage errors
+    func pruneHolderIdentifiers() throws
 }

--- a/WalletLibrary/WalletLibrary/Protocols/Storage/HolderIdentifierStorage.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Storage/HolderIdentifierStorage.swift
@@ -19,4 +19,10 @@ protocol HolderIdentifierStorage
     ///   - keyId: A `UUID` that uniquely identifies the holder in persistent storage.
     /// - Throws: A `CoreDataManagerError.persistentStoreNotLoaded` error if the persistent store is not loaded, or other errors related to saving the context.
     func storeHolderIdentifier(holderIdentifier: HolderIdentifierStoredProperties) throws
+    
+    /// Deletes the `HolderIdentifierStoredProperties` from storage `forKeyId`.
+    /// - Parameters:
+    ///   - identifier: `HolderIdentifierStoredProperties` to delete
+    /// - Throws:A `CoreDataManagerError.persistentStoreNotLoaded` error if the persistent store is not loaded, or other errors related to saving the context.
+    func deleteHolderIdentifier(identifier: HolderIdentifierStoredProperties) throws
 }

--- a/WalletLibrary/WalletLibrary/Repositories/IdentifierRepository.swift
+++ b/WalletLibrary/WalletLibrary/Repositories/IdentifierRepository.swift
@@ -40,26 +40,54 @@ class IdentifierRepository: HolderIdentifierRepository
         /// We only support one `HolderIdentifier` per user as of now.
         if let firstHolderIdentifier = storedHolderIdentifier.first
         {
+            logger.logVerbose(message: "An existing HolderIdentifier was found")
+            return try mapToHolderIdentifier(storedIdentifier: firstHolderIdentifier)
+        }
+        else
+        {
+            // If there are no identifiers in storage, create default one using FIPS compliant keys
+            // and "did:jwk" method. The key reference is always "0" for "did:jwk" dids.
+            logger.logVerbose(message: "Creating a new HolderIdentifier")
+            let mainIdentifier = try builder.buildHolderIdentifier(didMethod: "did:jwk",
+                                                                   id: nil,
+                                                                   keyId: nil,
+                                                                   keyReference: "0",
+                                                                   algorithm: "ES256")
+            try storeNewIdentifier(identifier: mainIdentifier)
+            logger.logInfo(message: "New HolderIdentifier created")
+            
+            return mainIdentifier
+        }
+    }
+    
+    /// Prunes the repository of `HolderIdentifier`s with no keychain material
+    func pruneHolderIdentifiers() throws
+    {
+        logger.logVerbose(message: "Fetching HolderIdentifiers")
+        let storedHolderIdentifier = try storage.fetchStoredHolderIdentifiers()
+        
+        logger.logVerbose(message: "Found \(storedHolderIdentifier.count) HolderIdentifiers")
+        
+        for holderIdentifier in storedHolderIdentifier
+        {
             do {
-                logger.logVerbose(message: "An existing HolderIdentifier was found")
-                return try mapToHolderIdentifier(storedIdentifier: firstHolderIdentifier)
+                // attempt resolving identifiers
+                _ = try mapToHolderIdentifier(storedIdentifier: holderIdentifier)
             } catch (let error as SecretStoringError) {
-                logger.logWarning(message: "Stored HolderIdentifier has crypto key material error: \(String(describing: error))")
+                switch error
+                {
+                case .invalidType, .invalidItemInStore, .itemNotFound:
+                    do {
+                        logger.logVerbose(message: "Pruning HolderIdentifier with keyId: \(String(describing: holderIdentifier.keyId)) (\(String(describing: error)))")
+                        try storage.deleteHolderIdentifier(identifier: holderIdentifier)
+                    } catch {
+                        logger.logError(message: "Failed to prune HolderIdentifier with keyid: \(String(describing: holderIdentifier.keyId)), \(String(describing: error))")
+                    }
+                default:
+                    logger.logError(message: "Unexpected error reading HolderIdentifier with keyid: \(String(describing: holderIdentifier.keyId)), \(String(describing: error))")
+                }
             }
         }
-        
-        // If there are no identifiers in storage, create default one using FIPS compliant keys
-        // and "did:jwk" method. The key reference is always "0" for "did:jwk" dids.
-        logger.logVerbose(message: "Creating a new HolderIdentifier")
-        let mainIdentifier = try builder.buildHolderIdentifier(didMethod: "did:jwk",
-                                                               id: nil,
-                                                               keyId: nil,
-                                                               keyReference: "0",
-                                                               algorithm: "ES256")
-        try storeNewIdentifier(identifier: mainIdentifier)
-        logger.logInfo(message: "New HolderIdentifier created")
-        
-        return mainIdentifier
     }
     
     private func mapToHolderIdentifier(storedIdentifier: HolderIdentifierStoredProperties) throws -> HolderIdentifier

--- a/WalletLibrary/WalletLibrary/Repositories/IdentifierRepository.swift
+++ b/WalletLibrary/WalletLibrary/Repositories/IdentifierRepository.swift
@@ -40,24 +40,26 @@ class IdentifierRepository: HolderIdentifierRepository
         /// We only support one `HolderIdentifier` per user as of now.
         if let firstHolderIdentifier = storedHolderIdentifier.first
         {
-            logger.logVerbose(message: "An existing HolderIdentifier was found")
-            return try mapToHolderIdentifier(storedIdentifier: firstHolderIdentifier)
+            do {
+                logger.logVerbose(message: "An existing HolderIdentifier was found")
+                return try mapToHolderIdentifier(storedIdentifier: firstHolderIdentifier)
+            } catch (let error as SecretStoringError) {
+                logger.logWarning(message: "Stored HolderIdentifier has crypto key material error: \(String(describing: error))")
+            }
         }
-        else
-        {
-            // If there are no identifiers in storage, create default one using FIPS compliant keys
-            // and "did:jwk" method. The key reference is always "0" for "did:jwk" dids.
-            logger.logVerbose(message: "Creating a new HolderIdentifier")
-            let mainIdentifier = try builder.buildHolderIdentifier(didMethod: "did:jwk",
-                                                                   id: nil,
-                                                                   keyId: nil,
-                                                                   keyReference: "0",
-                                                                   algorithm: "ES256")
-            try storeNewIdentifier(identifier: mainIdentifier)
-            logger.logInfo(message: "New HolderIdentifier created")
-            
-            return mainIdentifier
-        }
+        
+        // If there are no identifiers in storage, create default one using FIPS compliant keys
+        // and "did:jwk" method. The key reference is always "0" for "did:jwk" dids.
+        logger.logVerbose(message: "Creating a new HolderIdentifier")
+        let mainIdentifier = try builder.buildHolderIdentifier(didMethod: "did:jwk",
+                                                               id: nil,
+                                                               keyId: nil,
+                                                               keyReference: "0",
+                                                               algorithm: "ES256")
+        try storeNewIdentifier(identifier: mainIdentifier)
+        logger.logInfo(message: "New HolderIdentifier created")
+        
+        return mainIdentifier
     }
     
     private func mapToHolderIdentifier(storedIdentifier: HolderIdentifierStoredProperties) throws -> HolderIdentifier

--- a/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedIdClientBuilder.swift
@@ -79,6 +79,7 @@ public class VerifiedIdClientBuilder
     
     private func getAllIdentifiers(previewFeatureFlags: PreviewFeatureFlags) -> [HolderIdentifier]
     {
+        
         if previewFeatureFlags.isPreviewFeatureSupported(PreviewFeatureFlags.FIPSCompliantIdentifier),
            let holderIdentifier = getMainHolderIdentifier()
         {
@@ -100,6 +101,15 @@ public class VerifiedIdClientBuilder
     
     private func getMainHolderIdentifier() -> HolderIdentifier?
     {
+        do
+        {
+            try identifierRepository.pruneHolderIdentifiers()
+        }
+        catch
+        {
+            logger.logWarning(message: "Unable to prune Holder Identifiers from repository, \(String(describing: error))")
+        }
+        
         do
         {
             let holderIdentifier = try identifierRepository.getMainHolderIdentifier()

--- a/WalletLibrary/WalletLibraryTests/Extensions/Mappings/VCSDK/Presentation/PresentationRequest+MappableTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Extensions/Mappings/VCSDK/Presentation/PresentationRequest+MappableTests.swift
@@ -128,7 +128,8 @@ class PresentationRequestMappingTests: XCTestCase {
                                                   clientPurpose: nil,
                                                   logoURI: nil,
                                                   subjectIdentifierTypesSupported: nil,
-                                                  vpFormats: nil)
+                                                  vpFormats: nil,
+                                                  scenario: nil)
         let token = createPresentationRequestToken(registration: mockRegistration)
         
         let expectedRootOfTrust = RootOfTrust(verified: false, source: "")
@@ -177,7 +178,8 @@ class PresentationRequestMappingTests: XCTestCase {
                                                   clientPurpose: nil,
                                                   logoURI: nil,
                                                   subjectIdentifierTypesSupported: nil,
-                                                  vpFormats: nil)
+                                                  vpFormats: nil,
+                                                  scenario: nil)
         let token = createPresentationRequestToken(registration: mockRegistration,
                                                    callbackUrl: nil)
         
@@ -225,7 +227,8 @@ class PresentationRequestMappingTests: XCTestCase {
                                                   clientPurpose: nil,
                                                   logoURI: nil,
                                                   subjectIdentifierTypesSupported: nil,
-                                                  vpFormats: nil)
+                                                  vpFormats: nil,
+                                                  scenario: nil)
         let token = createPresentationRequestToken(requestedClaims: mockRequestClaims,
                                                    registration: mockRegistration,
                                                    callbackUrl: "//|\\")
@@ -274,7 +277,8 @@ class PresentationRequestMappingTests: XCTestCase {
                                                   clientPurpose: nil,
                                                   logoURI: nil,
                                                   subjectIdentifierTypesSupported: nil,
-                                                  vpFormats: nil)
+                                                  vpFormats: nil,
+                                                  scenario: nil)
         let token = createPresentationRequestToken(requestedClaims: mockRequestClaims,
                                                    registration: mockRegistration,
                                                    state: nil)
@@ -323,7 +327,8 @@ class PresentationRequestMappingTests: XCTestCase {
                                                   clientPurpose: nil,
                                                   logoURI: nil,
                                                   subjectIdentifierTypesSupported: nil,
-                                                  vpFormats: nil)
+                                                  vpFormats: nil,
+                                                  scenario: nil)
         let token = createPresentationRequestToken(registration: mockRegistration)
         
         let expectedRootOfTrust = RootOfTrust(verified: false, source: "")
@@ -375,7 +380,8 @@ class PresentationRequestMappingTests: XCTestCase {
                                                   clientPurpose: nil,
                                                   logoURI: "https://test.com",
                                                   subjectIdentifierTypesSupported: nil,
-                                                  vpFormats: nil)
+                                                  vpFormats: nil,
+                                                  scenario: nil)
         let token = createPresentationRequestToken(registration: mockRegistration)
         
         let expectedRootOfTrust = RootOfTrust(verified: false, source: "")
@@ -426,7 +432,8 @@ class PresentationRequestMappingTests: XCTestCase {
                                                   clientPurpose: nil,
                                                   logoURI: nil,
                                                   subjectIdentifierTypesSupported: nil,
-                                                  vpFormats: nil)
+                                                  vpFormats: nil,
+                                                  scenario: nil)
         let token = createPresentationRequestToken(registration: mockRegistration,
                                                    idTokenHint: "mock idToken hint")
         
@@ -483,7 +490,8 @@ class PresentationRequestMappingTests: XCTestCase {
                                                   clientPurpose: nil,
                                                   logoURI: nil,
                                                   subjectIdentifierTypesSupported: nil,
-                                                  vpFormats: nil)
+                                                  vpFormats: nil,
+                                                  scenario: nil)
         let pinDescriptor = PinDescriptor(type: "mock pin type",
                                           length: 4,
                                           hash: "mock hash",

--- a/WalletLibrary/WalletLibraryTests/Identifier/Builders/KeychainHolderIdentifierBuilderTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Identifier/Builders/KeychainHolderIdentifierBuilderTests.swift
@@ -19,7 +19,7 @@ class KeychainHolderIdentifierBuilderTests: XCTestCase
         
         let mockCryptoOperations = MockCryptoOperations()
         let mockKeyManagementOperations = MockKeyManagementOperations(secretStore: SecretStoreMock())
-        let builder = KeychainHolderIdentifierBuilder(keyManagementOperations: mockKeyManagementOperations,
+        let builder = KeychainHolderIdentifierBuilder(logger:  WalletLibraryLogger(), keyManagementOperations: mockKeyManagementOperations,
                                                       cryptoOperations: mockCryptoOperations)
         
         // Act / Assert
@@ -47,7 +47,7 @@ class KeychainHolderIdentifierBuilderTests: XCTestCase
         let mockCryptoOperations = MockCryptoOperations()
         let mockKeyManagementOperations = MockKeyManagementOperations(secretStore: SecretStoreMock(),
                                                                       expectedGenerateKeyError: expectedError)
-        let builder = KeychainHolderIdentifierBuilder(keyManagementOperations: mockKeyManagementOperations,
+        let builder = KeychainHolderIdentifierBuilder(logger:  WalletLibraryLogger(), keyManagementOperations: mockKeyManagementOperations,
                                                       cryptoOperations: mockCryptoOperations)
         
         // Act / Assert
@@ -73,7 +73,7 @@ class KeychainHolderIdentifierBuilderTests: XCTestCase
         // Arrange
         let mockCryptoOperations = MockCryptoOperations(throwWhenGettingPublicKey: true)
         let mockKeyManagementOperations = MockKeyManagementOperations(secretStore: SecretStoreMock())
-        let builder = KeychainHolderIdentifierBuilder(keyManagementOperations: mockKeyManagementOperations,
+        let builder = KeychainHolderIdentifierBuilder(logger:  WalletLibraryLogger(), keyManagementOperations: mockKeyManagementOperations,
                                                       cryptoOperations: mockCryptoOperations)
         
         // Act / Assert
@@ -90,7 +90,7 @@ class KeychainHolderIdentifierBuilderTests: XCTestCase
         // Arrange
         let mockCryptoOperations = MockCryptoOperations()
         let mockKeyManagementOperations = MockKeyManagementOperations(secretStore: SecretStoreMock())
-        let builder = KeychainHolderIdentifierBuilder(keyManagementOperations: mockKeyManagementOperations,
+        let builder = KeychainHolderIdentifierBuilder(logger:  WalletLibraryLogger(), keyManagementOperations: mockKeyManagementOperations,
                                                       cryptoOperations: mockCryptoOperations)
         
         // Act / Assert
@@ -116,7 +116,7 @@ class KeychainHolderIdentifierBuilderTests: XCTestCase
         let mockPublicKey = ES256PublicKey(x: Data(count: 32), y: Data(count: 32))!
         let mockCryptoOperations = MockCryptoOperations(publicKey: mockPublicKey)
         let mockKeyManagementOperations = MockKeyManagementOperations(secretStore: SecretStoreMock())
-        let builder = KeychainHolderIdentifierBuilder(keyManagementOperations: mockKeyManagementOperations,
+        let builder = KeychainHolderIdentifierBuilder(logger:  WalletLibraryLogger(), keyManagementOperations: mockKeyManagementOperations,
                                                       cryptoOperations: mockCryptoOperations)
         
         // Act

--- a/WalletLibrary/WalletLibraryTests/Mocks/Repositories/MockIdentifierRepository.swift
+++ b/WalletLibrary/WalletLibraryTests/Mocks/Repositories/MockIdentifierRepository.swift
@@ -9,23 +9,33 @@ struct MockIdentifierRepository: HolderIdentifierRepository
 {
     private let expectedIdentifier: HolderIdentifier?
     
-    private let expectedErrorThrown: Error?
+    private let expectedSaveErrorThrown: Error?
     
-    init(expectedIdentifier: HolderIdentifier? = nil, expectedErrorThrown: Error? = nil)
+    private let expectedDeleteErrorThrown: Error?
+    
+    init(expectedIdentifier: HolderIdentifier? = nil, expectedErrorThrown: Error? = nil, expectedPruneErrorThrown: Error? = nil)
     {
         self.expectedIdentifier = expectedIdentifier
-        self.expectedErrorThrown = expectedErrorThrown
+        self.expectedSaveErrorThrown = expectedErrorThrown
+        self.expectedDeleteErrorThrown = expectedPruneErrorThrown
     }
     
     func getMainHolderIdentifier() throws -> HolderIdentifier
     {
-        if let error = expectedErrorThrown
+        if let error = expectedSaveErrorThrown
         {
             throw error
         }
         else
         {
             return expectedIdentifier ?? MockHolderIdentifier()
+        }
+    }
+    
+    func pruneHolderIdentifiers() throws {
+        if let error = expectedDeleteErrorThrown
+        {
+            throw error
         }
     }
 }

--- a/WalletLibrary/WalletLibraryTests/Mocks/Requests/OpenId/MockTokenBuilders.swift
+++ b/WalletLibrary/WalletLibraryTests/Mocks/Requests/OpenId/MockTokenBuilders.swift
@@ -7,6 +7,7 @@
 
 struct MockTokenBuilderFactory: TokenBuilderFactory
 {
+    
     private let vpTokenBuilderSpy: ((Int) -> ())?
     
     private let doesPEIdTokenBuilderThrow: Bool
@@ -36,13 +37,15 @@ struct MockTokenBuilderFactory: TokenBuilderFactory
                                     expectedResult: expectedResultForPEIdToken)
     }
     
-    func createVerifiablePresentationBuilder(index: Int) ->VerifiablePresentationBuilding
+    func createVerifiablePresentationBuilder(index: Int, identifier: any WalletLibrary.HolderIdentifier) ->VerifiablePresentationBuilding
     {
         vpTokenBuilderSpy?(index)
         return MockVPBuilder(index: index,
                              doesThrow: doesVPTokenBuilderThrow,
-                             expectedResult: expectedResultForVPToken)
+                             expectedResult: expectedResultForVPToken,
+                             identifier: identifier)
     }
+    
 }
 
 struct MockPEIdTokenBuilder: PresentationExchangeIdTokenBuilding
@@ -94,9 +97,10 @@ struct MockVPBuilder: VerifiablePresentationBuilding
     
     init(index: Int,
          doesThrow: Bool = false,
-         expectedResult: VerifiablePresentation)
+         expectedResult: VerifiablePresentation,
+         identifier: HolderIdentifier)
     {
-        self.wrappedBuilder = VerifiablePresentationBuilder(index: index)
+        self.wrappedBuilder = VerifiablePresentationBuilder(index: index, identifier: identifier)
         self.doesThrow = doesThrow
         self.expectedResult = expectedResult
     }
@@ -117,8 +121,7 @@ struct MockVPBuilder: VerifiablePresentationBuilding
     }
     
     func buildVerifiablePresentation(audience: String,
-                                     nonce: String,
-                                     identifier: HolderIdentifier) throws -> VerifiablePresentation
+                                     nonce: String) throws -> VerifiablePresentation
     {
         if doesThrow
         {

--- a/WalletLibrary/WalletLibraryTests/Mocks/Storage/MockHolderIdentifierStorage.swift
+++ b/WalletLibrary/WalletLibraryTests/Mocks/Storage/MockHolderIdentifierStorage.swift
@@ -11,15 +11,19 @@ struct MockHolderIdentifierStorage: HolderIdentifierStorage
     
     private let expectedErrorToThrowForStoring: Error?
     
+    private let expectedErrorToTHrowForDeleting: Error?
+    
     private let expectedHolderIdentifierProperties: [HolderIdentifierStoredProperties]
     
     init(expectedErrorToThrowForFetching: Error?,
          expectedErrorToThrowForStoring: Error?,
-         expectedHolderIdentifierProperties: [HolderIdentifierStoredProperties] = [])
+         expectedHolderIdentifierProperties: [HolderIdentifierStoredProperties] = [],
+         expectedErrorToThrowForDeleting: Error?)
     {
         self.expectedErrorToThrowForFetching = expectedErrorToThrowForFetching
         self.expectedErrorToThrowForStoring = expectedErrorToThrowForStoring
         self.expectedHolderIdentifierProperties = expectedHolderIdentifierProperties
+        self.expectedErrorToTHrowForDeleting = expectedErrorToThrowForDeleting
     }
     
     func fetchStoredHolderIdentifiers() throws -> [HolderIdentifierStoredProperties]
@@ -35,6 +39,14 @@ struct MockHolderIdentifierStorage: HolderIdentifierStorage
     func storeHolderIdentifier(holderIdentifier: HolderIdentifierStoredProperties) throws
     {
         if let error = expectedErrorToThrowForStoring
+        {
+            throw error
+        }
+    }
+    
+    func deleteHolderIdentifier(identifier: any WalletLibrary.HolderIdentifierStoredProperties) throws
+    {
+        if let error = expectedErrorToTHrowForDeleting
         {
             throw error
         }

--- a/WalletLibrary/WalletLibraryTests/Mocks/Storage/MockHolderIdentifierStorage.swift
+++ b/WalletLibrary/WalletLibraryTests/Mocks/Storage/MockHolderIdentifierStorage.swift
@@ -11,7 +11,7 @@ struct MockHolderIdentifierStorage: HolderIdentifierStorage
     
     private let expectedErrorToThrowForStoring: Error?
     
-    private let expectedErrorToTHrowForDeleting: Error?
+    private let expectedErrorToThrowForDeleting: Error?
     
     private let expectedHolderIdentifierProperties: [HolderIdentifierStoredProperties]
     
@@ -23,7 +23,7 @@ struct MockHolderIdentifierStorage: HolderIdentifierStorage
         self.expectedErrorToThrowForFetching = expectedErrorToThrowForFetching
         self.expectedErrorToThrowForStoring = expectedErrorToThrowForStoring
         self.expectedHolderIdentifierProperties = expectedHolderIdentifierProperties
-        self.expectedErrorToTHrowForDeleting = expectedErrorToThrowForDeleting
+        self.expectedErrorToThrowForDeleting = expectedErrorToThrowForDeleting
     }
     
     func fetchStoredHolderIdentifiers() throws -> [HolderIdentifierStoredProperties]
@@ -46,7 +46,7 @@ struct MockHolderIdentifierStorage: HolderIdentifierStorage
     
     func deleteHolderIdentifier(identifier: any WalletLibrary.HolderIdentifierStoredProperties) throws
     {
-        if let error = expectedErrorToTHrowForDeleting
+        if let error = expectedErrorToThrowForDeleting
         {
             throw error
         }

--- a/WalletLibrary/WalletLibraryTests/Repositories/IdentifierRepositoryTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Repositories/IdentifierRepositoryTests.swift
@@ -15,9 +15,10 @@ class IdentifierRepositoryTests: XCTestCase
         let mockBuilder = MockHolderIdentifierBuilder(expectedErrorToThrow: nil,
                                                       expectedHolderIdentifier: nil)
         let mockStorage = MockHolderIdentifierStorage(expectedErrorToThrowForFetching: expectedError,
-                                                      expectedErrorToThrowForStoring: nil)
+                                                      expectedErrorToThrowForStoring: nil,
+                                                      expectedErrorToThrowForDeleting: nil)
         
-        let repository = IdentifierRepository(builder: mockBuilder,
+        let repository = IdentifierRepository(logger: WalletLibraryLogger(), builder: mockBuilder,
                                               storage: mockStorage)
         
         // Act / Assert
@@ -43,9 +44,11 @@ class IdentifierRepositoryTests: XCTestCase
         let mockBuilder = MockHolderIdentifierBuilder(expectedErrorToThrow: expectedError,
                                                       expectedHolderIdentifier: nil)
         let mockStorage = MockHolderIdentifierStorage(expectedErrorToThrowForFetching: nil,
-                                                      expectedErrorToThrowForStoring: nil)
+                                                      expectedErrorToThrowForStoring: nil,
+                                                      expectedErrorToThrowForDeleting: nil)
         
-        let repository = IdentifierRepository(builder: mockBuilder,
+        let repository = IdentifierRepository(logger:  WalletLibraryLogger(),
+                                              builder: mockBuilder,
                                               storage: mockStorage)
         
         // Act / Assert
@@ -70,9 +73,11 @@ class IdentifierRepositoryTests: XCTestCase
         let mockBuilder = MockHolderIdentifierBuilder(expectedErrorToThrow: nil,
                                                       expectedHolderIdentifier: nil)
         let mockStorage = MockHolderIdentifierStorage(expectedErrorToThrowForFetching: nil,
-                                                      expectedErrorToThrowForStoring: nil)
+                                                      expectedErrorToThrowForStoring: nil,
+                                                      expectedErrorToThrowForDeleting: nil)
         
-        let repository = IdentifierRepository(builder: mockBuilder,
+        let repository = IdentifierRepository(logger:  WalletLibraryLogger(),
+                                              builder: mockBuilder,
                                               storage: mockStorage)
         
         // Act / Assert
@@ -104,9 +109,11 @@ class IdentifierRepositoryTests: XCTestCase
         let mockBuilder = MockHolderIdentifierBuilder(expectedErrorToThrow: nil,
                                                       expectedHolderIdentifier: keychainIdentifier)
         let mockStorage = MockHolderIdentifierStorage(expectedErrorToThrowForFetching: nil,
-                                                      expectedErrorToThrowForStoring: expectedError)
+                                                      expectedErrorToThrowForStoring: expectedError,
+                                                      expectedErrorToThrowForDeleting: nil)
         
-        let repository = IdentifierRepository(builder: mockBuilder,
+        let repository = IdentifierRepository(logger:  WalletLibraryLogger(),
+                                              builder: mockBuilder,
                                               storage: mockStorage)
         
         // Act / Assert
@@ -137,9 +144,11 @@ class IdentifierRepositoryTests: XCTestCase
                                                       expectedHolderIdentifier: nil)
         let mockStorage = MockHolderIdentifierStorage(expectedErrorToThrowForFetching: nil,
                                                       expectedErrorToThrowForStoring: nil,
-                                                      expectedHolderIdentifierProperties: [mockProperties])
+                                                      expectedHolderIdentifierProperties: [mockProperties],
+                                                      expectedErrorToThrowForDeleting: nil)
         
-        let repository = IdentifierRepository(builder: mockBuilder,
+        let repository = IdentifierRepository(logger:  WalletLibraryLogger(),
+                                              builder: mockBuilder,
                                               storage: mockStorage)
         
         // Act / Assert
@@ -169,9 +178,11 @@ class IdentifierRepositoryTests: XCTestCase
                                                       expectedHolderIdentifier: nil)
         let mockStorage = MockHolderIdentifierStorage(expectedErrorToThrowForFetching: nil,
                                                       expectedErrorToThrowForStoring: nil,
-                                                      expectedHolderIdentifierProperties: [mockProperties])
+                                                      expectedHolderIdentifierProperties: [mockProperties],
+                                                      expectedErrorToThrowForDeleting: nil)
         
-        let repository = IdentifierRepository(builder: mockBuilder,
+        let repository = IdentifierRepository(logger:  WalletLibraryLogger(),
+                                              builder: mockBuilder,
                                               storage: mockStorage)
         
         // Act / Assert
@@ -203,9 +214,10 @@ class IdentifierRepositoryTests: XCTestCase
                                                       expectedHolderIdentifier: nil)
         let mockStorage = MockHolderIdentifierStorage(expectedErrorToThrowForFetching: nil,
                                                       expectedErrorToThrowForStoring: nil,
-                                                      expectedHolderIdentifierProperties: [mockProperties])
+                                                      expectedHolderIdentifierProperties: [mockProperties],
+                                                      expectedErrorToThrowForDeleting: nil)
         
-        let repository = IdentifierRepository(builder: mockBuilder,
+        let repository = IdentifierRepository(logger: WalletLibraryLogger(), builder: mockBuilder,
                                               storage: mockStorage)
         
         // Act / Assert
@@ -237,9 +249,11 @@ class IdentifierRepositoryTests: XCTestCase
                                                       expectedHolderIdentifier: nil)
         let mockStorage = MockHolderIdentifierStorage(expectedErrorToThrowForFetching: nil,
                                                       expectedErrorToThrowForStoring: nil,
-                                                      expectedHolderIdentifierProperties: [mockProperties])
+                                                      expectedHolderIdentifierProperties: [mockProperties],
+                                                      expectedErrorToThrowForDeleting: nil)
         
-        let repository = IdentifierRepository(builder: mockBuilder,
+        let repository = IdentifierRepository(logger:  WalletLibraryLogger(),
+                                              builder: mockBuilder,
                                               storage: mockStorage)
         
         // Act / Assert
@@ -272,9 +286,11 @@ class IdentifierRepositoryTests: XCTestCase
         let mockBuilder = MockHolderIdentifierBuilder(expectedErrorToThrow: nil,
                                                       expectedHolderIdentifier: keychainIdentifier)
         let mockStorage = MockHolderIdentifierStorage(expectedErrorToThrowForFetching: nil,
-                                                      expectedErrorToThrowForStoring: nil)
+                                                      expectedErrorToThrowForStoring: nil,
+                                                      expectedErrorToThrowForDeleting: nil)
         
-        let repository = IdentifierRepository(builder: mockBuilder,
+        let repository = IdentifierRepository(logger:  WalletLibraryLogger(),
+                                              builder: mockBuilder,
                                               storage: mockStorage)
         
         // Act
@@ -307,9 +323,11 @@ class IdentifierRepositoryTests: XCTestCase
                                                       expectedHolderIdentifier: keychainIdentifier)
         let mockStorage = MockHolderIdentifierStorage(expectedErrorToThrowForFetching: nil,
                                                       expectedErrorToThrowForStoring: nil,
-                                                      expectedHolderIdentifierProperties: [mockProperties])
+                                                      expectedHolderIdentifierProperties: [mockProperties],
+                                                      expectedErrorToThrowForDeleting: nil)
         
-        let repository = IdentifierRepository(builder: mockBuilder,
+        let repository = IdentifierRepository(logger:  WalletLibraryLogger(),
+                                              builder: mockBuilder,
                                               storage: mockStorage)
         
         // Act

--- a/WalletLibrary/WalletLibraryTests/Repositories/IdentifierRepositoryTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Repositories/IdentifierRepositoryTests.swift
@@ -340,6 +340,108 @@ class IdentifierRepositoryTests: XCTestCase
         XCTAssertEqual(result.keyReference, keychainIdentifier.keyReference)
         XCTAssertEqual(result.method, keychainIdentifier.method)
     }
+    
+    func testPruneHolderIdentifiers_WhenNoCredentialsExist_DoesNotThrow()
+    {
+        // Arrange
+        let keyId = UUID()
+
+        let mockBuilder = MockHolderIdentifierBuilder(expectedErrorToThrow: nil,
+                                                      expectedHolderIdentifier: nil)
+        let mockStorage = MockHolderIdentifierStorage(expectedErrorToThrowForFetching: nil,
+                                                      expectedErrorToThrowForStoring: nil,
+                                                      expectedHolderIdentifierProperties: [],
+                                                      expectedErrorToThrowForDeleting: nil)
+        
+        let repository = IdentifierRepository(logger:  WalletLibraryLogger(),
+                                              builder: mockBuilder,
+                                              storage: mockStorage)
+        
+        do
+        {
+            // Act
+            try repository.pruneHolderIdentifiers()
+        }
+        catch
+        {
+            // Assert
+            XCTFail("Expected not to throw")
+        }
+    }
+    
+    func testPruneHolderIdentifiers_WhenIdentifierExists_DoesNotPrune()
+    {
+        // Arrange
+        let keyId = UUID()
+        let mockProperties = MockStoredHolderIdentifierProperties(keyId: keyId,
+                                                                  didMethod: "mockDidMethod",
+                                                                  algorithm: "mockAlgorithm",
+                                                                  keyReference: "mockKeyReference")
+        let keychainIdentifier = KeychainIdentifier(id: "mockId",
+                                                    algorithm: "mockAlgorithm",
+                                                    method: "mockMethod",
+                                                    keyReference: "mockKeyReference",
+                                                    keyReferenceSecret: MockCryptoSecret(id: UUID()),
+                                                    cryptoOperations: MockCryptoOperations())
+
+        let mockBuilder = MockHolderIdentifierBuilder(expectedErrorToThrow: nil,
+                                                      expectedHolderIdentifier: keychainIdentifier)
+        
+        let failureException = VerifiedIdError(message: "Not expected to delete", code: "test_failed")
+        
+        let mockStorage = MockHolderIdentifierStorage(expectedErrorToThrowForFetching: nil,
+                                                      expectedErrorToThrowForStoring: nil,
+                                                      expectedHolderIdentifierProperties: [mockProperties],
+                                                      expectedErrorToThrowForDeleting: failureException)
+        
+        let repository = IdentifierRepository(logger:  WalletLibraryLogger(),
+                                              builder: mockBuilder,
+                                              storage: mockStorage)
+        
+        do
+        {
+            // Act
+            try repository.pruneHolderIdentifiers()
+        }
+        catch
+        {
+            // Assert
+            XCTFail("Expected not to throw")
+        }
+    }
+    
+    func testPruneHolderIdentifiers_WhenIdentifierMissingCrypto_Prunes()
+    {
+        // Arrange
+        let keyId = UUID()
+        let mockProperties = MockStoredHolderIdentifierProperties(keyId: keyId,
+                                                                  didMethod: "mockDidMethod",
+                                                                  algorithm: "mockAlgorithm",
+                                                                  keyReference: "mockKeyReference")
+        
+
+        let mockBuilder = MockHolderIdentifierBuilder(expectedErrorToThrow: SecretStoringError.itemNotFound,
+                                                      expectedHolderIdentifier: nil)
+        let mockStorage = MockHolderIdentifierStorage(expectedErrorToThrowForFetching: nil,
+                                                      expectedErrorToThrowForStoring: nil,
+                                                      expectedHolderIdentifierProperties: [mockProperties],
+                                                      expectedErrorToThrowForDeleting: nil)
+        
+        let repository = IdentifierRepository(logger:  WalletLibraryLogger(),
+                                              builder: mockBuilder,
+                                              storage: mockStorage)
+        
+        do
+        {
+            // Act
+            try repository.pruneHolderIdentifiers()
+        }
+        catch
+        {
+            // Assert
+            XCTFail("Expected not to throw")
+        }
+    }
 }
 
 struct MockStoredHolderIdentifierProperties: HolderIdentifierStoredProperties

--- a/WalletLibrary/WalletLibraryTests/Requests/Manifest/ContractIssuanceRequestTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Requests/Manifest/ContractIssuanceRequestTests.swift
@@ -29,10 +29,13 @@ class ContractIssuanceRequestTests: XCTestCase {
                                              requirement: mockRequirement,
                                              rootOfTrust: mockRootOfTrust)
         
+        let mockRawRequest = MockOpenIdRawRequest(nonce: nil, state: nil, clientId: nil, definitionId: nil)
+        
         let contractIssuanceRequest = ContractIssuanceRequest(content: content,
                                                               issuanceResponseContainer: mockIssuanceResponseContainer,
                                                               verifiedIdRequester: mockVCRequester,
-                                                              configuration: configuration)
+                                                              configuration: configuration,
+                                                              rawRequest: mockRawRequest)
         
         // Act
         let actualResult = contractIssuanceRequest.isSatisfied()
@@ -58,6 +61,8 @@ class ContractIssuanceRequestTests: XCTestCase {
                                                requirements: [firstValidRequirement, invalidRequirement, secondValidRequirement],
                                                requirementOperator: .ALL)
         
+        let mockRawRequest = MockOpenIdRawRequest(nonce: nil, state: nil, clientId: nil, definitionId: nil)
+        
         
         let content = IssuanceRequestContent(style: mockStyle,
                                              verifiedIdStyle: MockVerifiedIdStyle(),
@@ -67,7 +72,8 @@ class ContractIssuanceRequestTests: XCTestCase {
         let contractIssuanceRequest = ContractIssuanceRequest(content: content,
                                                               issuanceResponseContainer: mockIssuanceResponseContainer,
                                                               verifiedIdRequester: mockVCRequester,
-                                                              configuration: configuration)
+                                                              configuration: configuration,
+                                                              rawRequest: mockRawRequest)
         
         // Act
         let actualResult = contractIssuanceRequest.isSatisfied()
@@ -92,10 +98,13 @@ class ContractIssuanceRequestTests: XCTestCase {
                                              requirement: validRequirement,
                                              rootOfTrust: mockRootOfTrust)
         
+        let mockRawRequest = MockOpenIdRawRequest(nonce: nil, state: nil, clientId: nil, definitionId: nil)
+        
         let contractIssuanceRequest = ContractIssuanceRequest(content: content,
                                                               issuanceResponseContainer: mockIssuanceResponseContainer,
                                                               verifiedIdRequester: mockVCRequester,
-                                                              configuration: configuration)
+                                                              configuration: configuration,
+                                                              rawRequest: mockRawRequest)
         
         // Act
         let actualResult = contractIssuanceRequest.isSatisfied()
@@ -125,10 +134,13 @@ class ContractIssuanceRequestTests: XCTestCase {
                                              requirement: mockRequirement,
                                              rootOfTrust: mockRootOfTrust)
         
+        let mockRawRequest = MockOpenIdRawRequest(nonce: nil, state: nil, clientId: nil, definitionId: nil)
+        
         let contractIssuanceRequest = ContractIssuanceRequest(content: content,
                                                               issuanceResponseContainer: mockIssuanceResponseContainer,
                                                               verifiedIdRequester: mockVCRequester,
-                                                              configuration: configuration)
+                                                              configuration: configuration,
+                                                              rawRequest: mockRawRequest)
         
         // Act
         let actualResult = contractIssuanceRequest.isSatisfied()
@@ -171,10 +183,13 @@ class ContractIssuanceRequestTests: XCTestCase {
                                              issuanceResultCallbackUrl: URL(string: "https://test.com")!,
                                              rootOfTrust: mockRootOfTrust)
         
+        let mockRawRequest = MockOpenIdRawRequest(nonce: nil, state: nil, clientId: nil, definitionId: nil)
+        
         let contractIssuanceRequest = ContractIssuanceRequest(content: content,
                                                               issuanceResponseContainer: mockIssuanceResponseContainer,
                                                               verifiedIdRequester: mockVCRequester,
-                                                              configuration: configuration)
+                                                              configuration: configuration,
+                                                              rawRequest: mockRawRequest)
         
         // Act
         let actualResult = await contractIssuanceRequest.complete()
@@ -217,10 +232,13 @@ class ContractIssuanceRequestTests: XCTestCase {
                                              requirement: mockRequirement,
                                              rootOfTrust: mockRootOfTrust)
         
+        let mockRawRequest = MockOpenIdRawRequest(nonce: nil, state: nil, clientId: nil, definitionId: nil)
+        
         let contractIssuanceRequest = ContractIssuanceRequest(content: content,
                                                               issuanceResponseContainer: mockIssuanceResponseContainer,
                                                               verifiedIdRequester: mockVCRequester,
-                                                              configuration: configuration)
+                                                              configuration: configuration,
+                                                              rawRequest: mockRawRequest)
         
         // Act
         let actualResult = await contractIssuanceRequest.complete()
@@ -268,10 +286,13 @@ class ContractIssuanceRequestTests: XCTestCase {
                                              issuanceResultCallbackUrl: URL(string: "https://test.com")!,
                                              rootOfTrust: mockRootOfTrust)
         
+        let mockRawRequest = MockOpenIdRawRequest(nonce: nil, state: nil, clientId: nil, definitionId: nil)
+        
         let contractIssuanceRequest = ContractIssuanceRequest(content: content,
                                                               issuanceResponseContainer: mockIssuanceResponseContainer,
                                                               verifiedIdRequester: mockVCRequester,
-                                                              configuration: configuration)
+                                                              configuration: configuration,
+                                                              rawRequest: mockRawRequest)
         
         // Act
         let actualResult = await contractIssuanceRequest.complete()
@@ -314,10 +335,13 @@ class ContractIssuanceRequestTests: XCTestCase {
                                              requirement: mockRequirement,
                                              rootOfTrust: mockRootOfTrust)
         
+        let mockRawRequest = MockOpenIdRawRequest(nonce: nil, state: nil, clientId: nil, definitionId: nil)
+        
         let contractIssuanceRequest = ContractIssuanceRequest(content: content,
                                                               issuanceResponseContainer: mockIssuanceResponseContainer,
                                                               verifiedIdRequester: mockVCRequester,
-                                                              configuration: configuration)
+                                                              configuration: configuration,
+                                                              rawRequest: mockRawRequest)
         
         // Act
         let actualResult = await contractIssuanceRequest.complete()
@@ -360,10 +384,13 @@ class ContractIssuanceRequestTests: XCTestCase {
                                              issuanceResultCallbackUrl: URL(string: "https://test.com")!,
                                              rootOfTrust: mockRootOfTrust)
         
+        let mockRawRequest = MockOpenIdRawRequest(nonce: nil, state: nil, clientId: nil, definitionId: nil)
+        
         let contractIssuanceRequest = ContractIssuanceRequest(content: content,
                                                               issuanceResponseContainer: mockIssuanceResponseContainer,
                                                               verifiedIdRequester: mockVCRequester,
-                                                              configuration: configuration)
+                                                              configuration: configuration,
+                                                              rawRequest: mockRawRequest)
         
         // Act
         let actualResult = await contractIssuanceRequest.cancel()
@@ -407,10 +434,13 @@ class ContractIssuanceRequestTests: XCTestCase {
                                              requestState: "mockState",
                                              rootOfTrust: mockRootOfTrust)
         
+        let mockRawRequest = MockOpenIdRawRequest(nonce: nil, state: nil, clientId: nil, definitionId: nil)
+        
         let contractIssuanceRequest = ContractIssuanceRequest(content: content,
                                                               issuanceResponseContainer: mockIssuanceResponseContainer,
                                                               verifiedIdRequester: mockVCRequester,
-                                                              configuration: configuration)
+                                                              configuration: configuration,
+                                                              rawRequest: mockRawRequest)
         
         // Act
         let actualResult = await contractIssuanceRequest.cancel()
@@ -459,10 +489,13 @@ class ContractIssuanceRequestTests: XCTestCase {
                                              issuanceResultCallbackUrl: URL(string: "https://test.com")!,
                                              rootOfTrust: mockRootOfTrust)
         
+        let mockRawRequest = MockOpenIdRawRequest(nonce: nil, state: nil, clientId: nil, definitionId: nil)
+        
         let contractIssuanceRequest = ContractIssuanceRequest(content: content,
                                                               issuanceResponseContainer: mockIssuanceResponseContainer,
                                                               verifiedIdRequester: mockVCRequester,
-                                                              configuration: configuration)
+                                                              configuration: configuration,
+                                                              rawRequest: mockRawRequest)
         
         // Act
         let actualResult = await contractIssuanceRequest.cancel()

--- a/WalletLibrary/WalletLibraryTests/Requests/OpenId/PresentationExchange/PresentationExchangeSerializerTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Requests/OpenId/PresentationExchange/PresentationExchangeSerializerTests.swift
@@ -146,7 +146,10 @@ class PresentationExchangeSerializerTests: XCTestCase
         }
         
         let mockTokenBuilderFactory = MockTokenBuilderFactory(vpTokenBuilderSpy: vpTokenBuilderSpy)
-        let configuration = LibraryConfiguration()
+        let mockIdentifier = MockHolderIdentifier()
+        let configuration = LibraryConfiguration(
+            identifiers: [mockIdentifier]
+        )
         
         let serializer = try PresentationExchangeSerializer(request: mockOpenIdRawRequest,
                                                             tokenBuilderFactory: mockTokenBuilderFactory,
@@ -173,7 +176,10 @@ class PresentationExchangeSerializerTests: XCTestCase
         }
         
         let mockTokenBuilderFactory = MockTokenBuilderFactory(vpTokenBuilderSpy: vpTokenBuilderSpy)
-        let configuration = LibraryConfiguration()
+        let mockIdentifier = MockHolderIdentifier()
+        let configuration = LibraryConfiguration(
+            identifiers: [mockIdentifier]
+        )
         
         let serializer = try PresentationExchangeSerializer(request: mockOpenIdRawRequest,
                                                             tokenBuilderFactory: mockTokenBuilderFactory,
@@ -203,7 +209,10 @@ class PresentationExchangeSerializerTests: XCTestCase
         }
         
         let mockTokenBuilderFactory = MockTokenBuilderFactory(vpTokenBuilderSpy: vpTokenBuilderSpy)
-        let configuration = LibraryConfiguration()
+        let mockIdentifier = MockHolderIdentifier()
+        let configuration = LibraryConfiguration(
+            identifiers: [mockIdentifier]
+        )
         
         let serializer = try PresentationExchangeSerializer(request: mockOpenIdRawRequest,
                                                             tokenBuilderFactory: mockTokenBuilderFactory,

--- a/WalletLibrary/WalletLibraryTests/Requests/OpenId/PresentationExchange/PresentationExchangeSerializerTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Requests/OpenId/PresentationExchange/PresentationExchangeSerializerTests.swift
@@ -119,7 +119,8 @@ class PresentationExchangeSerializerTests: XCTestCase
                            "Unable to add requirement to VP grouping: MockPresentationExchangeRequirement")
         }
         
-        let logger = WalletLibraryLogger(consumers: [MockLogConsumer(logCallback: callback)])
+        let logger = WalletLibraryLogger()
+        logger.add(consumer: MockLogConsumer(logCallback: callback))
         let configuration = LibraryConfiguration(logger: logger)
         
         let serializer = try PresentationExchangeSerializer(request: mockOpenIdRawRequest,

--- a/WalletLibrary/WalletLibraryTests/Requests/OpenId/PresentationExchange/VerifiablePresentationBuilderTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Requests/OpenId/PresentationExchange/VerifiablePresentationBuilderTests.swift
@@ -20,7 +20,7 @@ class VerifiablePresentationBuilderTests: XCTestCase
         
         let index = 1
         
-        let builder = VerifiablePresentationBuilder(index: index)
+        let builder = VerifiablePresentationBuilder(index: index, identifier: MockHolderIdentifier())
         builder.add(partialInputDescriptor: descriptor)
         
         // Act / Assert
@@ -41,7 +41,7 @@ class VerifiablePresentationBuilderTests: XCTestCase
         
         let index = 1
         
-        let builder = VerifiablePresentationBuilder(index: index)
+        let builder = VerifiablePresentationBuilder(index: index, identifier: MockHolderIdentifier())
         builder.add(partialInputDescriptor: descriptor1)
         builder.add(partialInputDescriptor: descriptor2)
         
@@ -57,7 +57,7 @@ class VerifiablePresentationBuilderTests: XCTestCase
         
         let index = 1
         
-        let builder = VerifiablePresentationBuilder(index: index)
+        let builder = VerifiablePresentationBuilder(index: index, identifier: MockHolderIdentifier())
         builder.add(partialInputDescriptor: input)
         
         // Act
@@ -87,7 +87,7 @@ class VerifiablePresentationBuilderTests: XCTestCase
         
         let index = 1
         
-        let builder = VerifiablePresentationBuilder(index: index)
+        let builder = VerifiablePresentationBuilder(index: index, identifier: MockHolderIdentifier())
         builder.add(partialInputDescriptor: descriptor1)
         builder.add(partialInputDescriptor: descriptor2)
         builder.add(partialInputDescriptor: descriptor3)
@@ -124,13 +124,12 @@ class VerifiablePresentationBuilderTests: XCTestCase
         
         let index = 1
         
-        let builder = VerifiablePresentationBuilder(index: index)
+        let builder = VerifiablePresentationBuilder(index: index, identifier: mockHolderIdentifier)
         builder.add(partialInputDescriptor: input)
         
         // Act
         let result = try builder.buildVerifiablePresentation(audience: mockAudience,
-                                                             nonce: mockNonce,
-                                                             identifier: mockHolderIdentifier)
+                                                             nonce: mockNonce)
         
         // Assert
         XCTAssertEqual(result.content.audience, mockAudience)
@@ -162,15 +161,14 @@ class VerifiablePresentationBuilderTests: XCTestCase
         
         let index = 1
         
-        let builder = VerifiablePresentationBuilder(index: index)
+        let builder = VerifiablePresentationBuilder(index: index, identifier: mockHolderIdentifier)
         builder.add(partialInputDescriptor: descriptor1)
         builder.add(partialInputDescriptor: descriptor2)
         builder.add(partialInputDescriptor: descriptor3)
         
         // Act
         let result = try builder.buildVerifiablePresentation(audience: mockAudience,
-                                                             nonce: mockNonce,
-                                                             identifier: mockHolderIdentifier)
+                                                             nonce: mockNonce)
         
         // Assert
         XCTAssertEqual(result.content.audience, mockAudience)
@@ -195,13 +193,12 @@ class VerifiablePresentationBuilderTests: XCTestCase
         
         let index = 1
         
-        let builder = VerifiablePresentationBuilder(index: index)
+        let builder = VerifiablePresentationBuilder(index: index, identifier: mockHolderIdentifier)
         builder.add(partialInputDescriptor: input)
         
         // Act / Assert
         XCTAssertThrowsError(try builder.buildVerifiablePresentation(audience: mockAudience,
-                                                                     nonce: mockNonce,
-                                                                     identifier: mockHolderIdentifier)) { error in
+                                                                     nonce: mockNonce)) { error in
             XCTAssert(error is VerifiedIdError)
             XCTAssertEqual((error as? VerifiedIdError)?.message, "expectedError")
             XCTAssertEqual((error as? VerifiedIdError)?.code, "expected_error")

--- a/WalletLibrary/WalletLibraryTests/Utilities/WalletLibraryLoggerTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Utilities/WalletLibraryLoggerTests.swift
@@ -30,7 +30,8 @@ class WalletLibraryLoggerTests: XCTestCase {
         // Arrange
         let testLogConsumer = testLogConsumer(with: .DEBUG)
         let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
-        let logger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let logger = WalletLibraryLogger()
+        logger.add(consumer: mockWalletLibraryLogConsumer)
         
         // Act
         logger.logDebug(message: mockMessage,
@@ -43,7 +44,8 @@ class WalletLibraryLoggerTests: XCTestCase {
         // Arrange
         let testLogConsumer = testLogConsumer(with: .INFO)
         let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
-        let logger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let logger = WalletLibraryLogger()
+        logger.add(consumer: mockWalletLibraryLogConsumer)
         
         // Act
         logger.logInfo(message: mockMessage,
@@ -56,7 +58,8 @@ class WalletLibraryLoggerTests: XCTestCase {
         // Arrange
         let testLogConsumer = testLogConsumer(with: .VERBOSE)
         let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
-        let logger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let logger = WalletLibraryLogger()
+        logger.add(consumer: mockWalletLibraryLogConsumer)
         
         // Act
         logger.logVerbose(message: mockMessage,
@@ -69,7 +72,8 @@ class WalletLibraryLoggerTests: XCTestCase {
         // Arrange
         let testLogConsumer = testLogConsumer(with: .WARN)
         let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
-        let logger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let logger = WalletLibraryLogger()
+        logger.add(consumer: mockWalletLibraryLogConsumer)
         
         // Act
         logger.logWarning(message: mockMessage,
@@ -82,7 +86,8 @@ class WalletLibraryLoggerTests: XCTestCase {
         // Arrange
         let testLogConsumer = testLogConsumer(with: .FAILURE)
         let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
-        let logger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let logger = WalletLibraryLogger()
+        logger.add(consumer: mockWalletLibraryLogConsumer)
         
         // Act
         logger.logFailure(message: mockMessage,
@@ -95,7 +100,8 @@ class WalletLibraryLoggerTests: XCTestCase {
         // Arrange
         let testLogConsumer = testLogConsumer(with: .ERROR)
         let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
-        let logger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let logger = WalletLibraryLogger()
+        logger.add(consumer: mockWalletLibraryLogConsumer)
         
         // Act
         logger.logError(message: mockMessage,
@@ -112,7 +118,8 @@ class WalletLibraryLoggerTests: XCTestCase {
         }
         
         let mockWalletLibraryLogConsumer = MockLogConsumer(eventCallback: eventCalled)
-        let logger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let logger = WalletLibraryLogger()
+        logger.add(consumer: mockWalletLibraryLogConsumer)
         
         // Act
         logger.event(name: mockName)

--- a/WalletLibrary/WalletLibraryTests/Utilities/WalletLibraryVCSDKLogConsumerTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Utilities/WalletLibraryVCSDKLogConsumerTests.swift
@@ -30,7 +30,8 @@ class WalletLibraryVCSDKLogConsumerTests: XCTestCase {
         // Arrange
         let testLogConsumer = testLogConsumer(with: .DEBUG)
         let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
-        let walletLibraryLogger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let walletLibraryLogger = WalletLibraryLogger()
+        walletLibraryLogger.add(consumer: mockWalletLibraryLogConsumer)
         let walletLibraryVCSDKLogConsumer = WalletLibraryVCSDKLogConsumer(logger: walletLibraryLogger)
         
         // Act
@@ -45,7 +46,8 @@ class WalletLibraryVCSDKLogConsumerTests: XCTestCase {
         // Arrange
         let testLogConsumer = testLogConsumer(with: .INFO)
         let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
-        let walletLibraryLogger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let walletLibraryLogger = WalletLibraryLogger()
+        walletLibraryLogger.add(consumer: mockWalletLibraryLogConsumer)
         let walletLibraryVCSDKLogConsumer = WalletLibraryVCSDKLogConsumer(logger: walletLibraryLogger)
         
         // Act
@@ -60,7 +62,8 @@ class WalletLibraryVCSDKLogConsumerTests: XCTestCase {
         // Arrange
         let testLogConsumer = testLogConsumer(with: .ERROR)
         let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
-        let walletLibraryLogger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let walletLibraryLogger = WalletLibraryLogger()
+        walletLibraryLogger.add(consumer: mockWalletLibraryLogConsumer)
         let walletLibraryVCSDKLogConsumer = WalletLibraryVCSDKLogConsumer(logger: walletLibraryLogger)
         
         // Act
@@ -75,7 +78,8 @@ class WalletLibraryVCSDKLogConsumerTests: XCTestCase {
         // Arrange
         let testLogConsumer = testLogConsumer(with: .FAILURE)
         let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
-        let walletLibraryLogger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let walletLibraryLogger = WalletLibraryLogger()
+        walletLibraryLogger.add(consumer: mockWalletLibraryLogConsumer)
         let walletLibraryVCSDKLogConsumer = WalletLibraryVCSDKLogConsumer(logger: walletLibraryLogger)
         
         // Act
@@ -90,7 +94,8 @@ class WalletLibraryVCSDKLogConsumerTests: XCTestCase {
         // Arrange
         let testLogConsumer = testLogConsumer(with: .WARN)
         let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
-        let walletLibraryLogger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let walletLibraryLogger = WalletLibraryLogger()
+        walletLibraryLogger.add(consumer: mockWalletLibraryLogConsumer)
         let walletLibraryVCSDKLogConsumer = WalletLibraryVCSDKLogConsumer(logger: walletLibraryLogger)
         
         // Act
@@ -105,7 +110,8 @@ class WalletLibraryVCSDKLogConsumerTests: XCTestCase {
         // Arrange
         let testLogConsumer = testLogConsumer(with: .VERBOSE)
         let mockWalletLibraryLogConsumer = MockLogConsumer(logCallback: testLogConsumer)
-        let walletLibraryLogger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let walletLibraryLogger = WalletLibraryLogger()
+        walletLibraryLogger.add(consumer: mockWalletLibraryLogConsumer)
         let walletLibraryVCSDKLogConsumer = WalletLibraryVCSDKLogConsumer(logger: walletLibraryLogger)
         
         // Act
@@ -124,7 +130,8 @@ class WalletLibraryVCSDKLogConsumerTests: XCTestCase {
         }
         
         let mockWalletLibraryLogConsumer = MockLogConsumer(eventCallback: eventCalled)
-        let walletLibraryLogger = WalletLibraryLogger(consumers: [mockWalletLibraryLogConsumer])
+        let walletLibraryLogger = WalletLibraryLogger()
+        walletLibraryLogger.add(consumer: mockWalletLibraryLogConsumer)
         let walletLibraryVCSDKLogConsumer = WalletLibraryVCSDKLogConsumer(logger: walletLibraryLogger)
         
         // Act


### PR DESCRIPTION
**Problem:**
Numerous reports when users use an iCloud restore of the app where issuances and presentations fail with cryptic errors "itemNotFound".


**Solution:**
itemNotFound returned from the keychain query during client building. 


**Validation:**
Unit tests

**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [x] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
3529155

**Documentation Links**: