### PR TITLE
Make Wallet Library Version Public

### DIFF
--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCNetworking/VCNetworking/WalletLibraryVersion.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCNetworking/VCNetworking/WalletLibraryVersion.swift
@@ -6,10 +6,10 @@
 /**
  * The Current Wallet Library Version.
  */
-struct WalletLibraryVersion {
-    static let High = 1
-    static let Low = 0
-    static let Patch = 0
+public struct WalletLibraryVersion {
+    public static let High = 1
+    public static let Low = 0
+    public static let Patch = 0
     
-    static let Version = "\(High).\(Low).\(Patch)"
+    public static let Version = "\(High).\(Low).\(Patch)"
 }


### PR DESCRIPTION
**Problem:**
`WalletLibraryVersion` struct and its members are `internal` (default access). The Authenticator app's `TelemetryClient` imports `VCNetworking` to access `WalletLibraryVersion.Version` for telemetry, but the test target (Debug/Simulator) cannot resolve the type across module boundaries, causing a build failure: `cannot find 'WalletLibraryVersion' in scope`.

**Solution:**
Made `WalletLibraryVersion` and all its static members `public` so they are accessible from any module that imports `VCNetworking`. This is a single-file, access-level-only change — no logic or behavioral changes.

**File changed:** `VCNetworking/VCNetworking/WalletLibraryVersion.swift`

```diff
- struct WalletLibraryVersion {
-     static let High = 1
-     static let Low = 0
-     static let Patch = 0
-     static let Version = "\(High).\(Low).\(Patch)"
+ public struct WalletLibraryVersion {
+     public static let High = 1
+     public static let Low = 0
+     public static let Patch = 0
+     public static let Version = "\(High).\(Low).\(Patch)"
```

**Validation:**
Access-level change only. No logic changes. The struct was already used internally by `NetworkOperation.swift` in the same module — making it public has no effect on existing usage. Fixes Authenticator CI test build failure (PR #15294099).

**Type of change:**
- [x] Engineering change

**Risk**:
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

**Work Item links**:
Related: Authenticator PR [#15294099](https://msazure.visualstudio.com/One/_git/AD-MFA-phonefactor-phoneApp-iPhone/pullrequest/15294099) — VID telemetry overhaul that references `WalletLibraryVersion.Version`.

**Documentation Links**:
N/A