### PR TITLE
Reduce log noise: NetworkOperation.fire() INFO → VERBOSE

### DIFF
--- a/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCNetworking/VCNetworking/operations/NetworkOperation.swift
+++ b/WalletLibrary/Submodules/VerifiableCredential-SDK-iOS/VCNetworking/VCNetworking/operations/NetworkOperation.swift
@@ -53,7 +53,7 @@ extension InternalNetworkOperation {
             cv.update()
             urlRequest.setValue(cv.value, forHTTPHeaderField: cv.name)
             
-            sdkLog.logInfo(message: "Correlation Vector for \(String(describing: self)): \(cv.value)")
+            sdkLog.logVerbose(message: "Correlation Vector for \(String(describing: self)): \(cv.value)")
         }
         
         return try await retryHandler.onRetry { [self] in


### PR DESCRIPTION
**Problem:**
`NetworkOperation.fire()` logs a correlation vector message at `INFO` level on every network call. In a typical session this produces **832 out of 2087 log lines (40%)**, drowning out actionable logs like errors, flow events, and warnings.

**Solution:**
Changed `sdkLog.logInfo` → `sdkLog.logVerbose` in `fire()`. The data is still available when verbose logging is enabled, but no longer clutters the default INFO-level view.

**File changed:** `VCNetworking/VCNetworking/operations/NetworkOperation.swift` (1 line)

```diff
- sdkLog.logInfo(message: "Correlation Vector for \(String(describing: self)): \(cv.value)")
+ sdkLog.logVerbose(message: "Correlation Vector for \(String(describing: self)): \(cv.value)")
```

**Validation:**
Single log-level change. No functional or behavioral impact. The CV is already included in `DIDNetworkMetrics` events at INFO level, so this is purely deduplication.

**Type of change:**
- [x] Logging/Telemetry

**Risk**:
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

**Work Item links**:
Related: Authenticator logging PR [#15336387](https://msazure.visualstudio.com/One/_git/AD-MFA-phonefactor-phoneApp-iPhone/pullrequest/15336387)

**Documentation Links**:
N/A