### PR TITLE
Expose credentialIssuer and credentialEndpoint on VerifiedIdIssuanceRequest

### DIFF
--- a/WalletLibrary/WalletLibrary/Protocols/Requests/Manifest/IssuanceResponseContaining.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Requests/Manifest/IssuanceResponseContaining.swift
@@ -8,7 +8,6 @@
  * For example, it is used as a wrapper to wrap the VC SDK issuance response container.
  */
 protocol IssuanceResponseContaining {
-    /// The audience URL the issuance response will be sent to (the credential issuer endpoint).
     var audienceUrl: String { get }
 
     mutating func add(requirement: Requirement) throws

--- a/WalletLibrary/WalletLibrary/Protocols/Requests/Manifest/IssuanceResponseContaining.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Requests/Manifest/IssuanceResponseContaining.swift
@@ -8,5 +8,8 @@
  * For example, it is used as a wrapper to wrap the VC SDK issuance response container.
  */
 protocol IssuanceResponseContaining {
+    /// The audience URL the issuance response will be sent to (the credential issuer endpoint).
+    var audienceUrl: String { get }
+
     mutating func add(requirement: Requirement) throws
 }

--- a/WalletLibrary/WalletLibrary/Protocols/Requests/VerifiedIdIssuanceRequest.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Requests/VerifiedIdIssuanceRequest.swift
@@ -15,4 +15,21 @@ public protocol VerifiedIdIssuanceRequest: VerifiedIdRequest where T == Verified
     var scenario: String? { get }
     
     var continuation: ContinuationDescriptor? { get }
+
+    /// The credential issuer endpoint URL.
+    ///
+    /// For legacy manifest issuance, this may also be the endpoint where the issuance response
+    /// is sent. For OpenID4VCI, prefer `credentialEndpoint` as the credential request POST target.
+    var credentialIssuer: String? { get }
+
+    /// The credential endpoint URL where the credential request/token is POSTed.
+    ///
+    /// This is available for OpenID4VCI issuance. It may be `nil` for legacy manifest issuance.
+    var credentialEndpoint: String? { get }
+}
+
+/// Default implementations preserve backward compatibility for existing protocol implementors.
+public extension VerifiedIdIssuanceRequest {
+    var credentialIssuer: String? { nil }
+    var credentialEndpoint: String? { nil }
 }

--- a/WalletLibrary/WalletLibrary/Protocols/Requests/VerifiedIdIssuanceRequest.swift
+++ b/WalletLibrary/WalletLibrary/Protocols/Requests/VerifiedIdIssuanceRequest.swift
@@ -17,18 +17,12 @@ public protocol VerifiedIdIssuanceRequest: VerifiedIdRequest where T == Verified
     var continuation: ContinuationDescriptor? { get }
 
     /// The credential issuer endpoint URL.
-    ///
-    /// For legacy manifest issuance, this may also be the endpoint where the issuance response
-    /// is sent. For OpenID4VCI, prefer `credentialEndpoint` as the credential request POST target.
     var credentialIssuer: String? { get }
 
-    /// The credential endpoint URL where the credential request/token is POSTed.
-    ///
-    /// This is available for OpenID4VCI issuance. It may be `nil` for legacy manifest issuance.
+    /// The credential endpoint URL. Will be `nil` for the manifest flow.
     var credentialEndpoint: String? { get }
 }
 
-/// Default implementations preserve backward compatibility for existing protocol implementors.
 public extension VerifiedIdIssuanceRequest {
     var credentialIssuer: String? { nil }
     var credentialEndpoint: String? { nil }

--- a/WalletLibrary/WalletLibrary/Requests/Manifest/ContractIssuanceRequest.swift
+++ b/WalletLibrary/WalletLibrary/Requests/Manifest/ContractIssuanceRequest.swift
@@ -27,7 +27,6 @@ class ContractIssuanceRequest: VerifiedIdIssuanceRequest
 
     public var credentialIssuer: String? { responseContainer.audienceUrl }
 
-    /// Legacy manifest flow uses `credentialIssuer` as the POST target.
     public var credentialEndpoint: String? { nil }
 
     let requestState: String?

--- a/WalletLibrary/WalletLibrary/Requests/Manifest/ContractIssuanceRequest.swift
+++ b/WalletLibrary/WalletLibrary/Requests/Manifest/ContractIssuanceRequest.swift
@@ -24,7 +24,12 @@ class ContractIssuanceRequest: VerifiedIdIssuanceRequest
     public let scenario: String?
     
     public let continuation: ContinuationDescriptor?
-    
+
+    public var credentialIssuer: String? { responseContainer.audienceUrl }
+
+    /// Legacy manifest flow uses `credentialIssuer` as the POST target.
+    public var credentialEndpoint: String? { nil }
+
     let requestState: String?
     
     let issuanceResultCallbackUrl: URL?

--- a/WalletLibrary/WalletLibrary/Requests/OpenId/OpenId4VCIRequest.swift
+++ b/WalletLibrary/WalletLibrary/Requests/OpenId/OpenId4VCIRequest.swift
@@ -26,7 +26,11 @@ class OpenId4VCIRequest: VerifiedIdIssuanceRequest
     
     /// The root of trust results between the request and the source of the request.
     public let rootOfTrust: RootOfTrust
-    
+
+    public var credentialIssuer: String? { credentialMetadata.credential_issuer }
+
+    public var credentialEndpoint: String? { credentialMetadata.credential_endpoint }
+
     /// The metadata about the credential being requested.
     private let credentialMetadata: CredentialMetadata
     


### PR DESCRIPTION
Expose credentialIssuer and credentialEndpoint on VerifiedIdIssuanceRequest, allowing consuming apps to access the issuance endpoint URLs for validation purposes.

**Type of change:**
- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.