### PR TITLE
Add VerifiedId status check (StatusList2021) to the wallet library

### DIFF
--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2ABE2AF6649EAD4BF92778D2 /* StatusCheckServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9DB54C60FA2A95C6332636 /* StatusCheckServiceTests.swift */; };
 		3043D92B5611982D88E50670 /* CollectionsQueryPostOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A32A62BBF9D9B5ECBC2483E /* CollectionsQueryPostOperation.swift */; };
 		5507A40B2BD99986003646EE /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 5507A40A2BD99986003646EE /* PrivacyInfo.xcprivacy */; };
 		550A913D29930D970014D030 /* MockRawRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550A913C29930D970014D030 /* MockRawRequest.swift */; };
@@ -1203,6 +1204,7 @@
 		A4F39A8A2B91571E005C12FC /* ExtensionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionConfiguration.swift; sourceTree = "<group>"; };
 		A7A381EDDE78BCFE7BC8C85B /* CredentialStatusDescriptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CredentialStatusDescriptor.swift; path = StatusCheck/CredentialStatusDescriptor.swift; sourceTree = "<group>"; };
 		CB866B76909C2AD2B0D52847 /* VerifiedIdStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VerifiedIdStatus.swift; sourceTree = "<group>"; };
+		DA9DB54C60FA2A95C6332636 /* StatusCheckServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StatusCheckServiceTests.swift; sourceTree = "<group>"; };
 		EE1B8B2800AA79BAED7CC9B7 /* StatusListCredentialFetchOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StatusListCredentialFetchOperation.swift; path = StatusCheck/StatusListCredentialFetchOperation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1450,6 +1452,7 @@
 				55265AD72B6C267300BAD6A2 /* LibraryConfigurationTests.swift */,
 				559BD30C2996C12500BD61AC /* VerifiedIdClientBuilderTests.swift */,
 				552E509F293E6AB200868F47 /* VerifiedIdClientTests.swift */,
+				E1C5D7D1C2EB62BA8B600708 /* StatusCheck */,
 			);
 			path = WalletLibraryTests;
 			sourceTree = "<group>";
@@ -3356,6 +3359,15 @@
 			name = StatusCheck;
 			sourceTree = "<group>";
 		};
+		E1C5D7D1C2EB62BA8B600708 /* StatusCheck */ = {
+			isa = PBXGroup;
+			children = (
+				DA9DB54C60FA2A95C6332636 /* StatusCheckServiceTests.swift */,
+			);
+			name = StatusCheck;
+			path = StatusCheck;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -4096,6 +4108,7 @@
 				55A268A82CC1B70300A8EA9C /* JwsHeaderFormatterTests.swift in Sources */,
 				559BD4F5299EEC9500BD61AC /* MockVerifiedIdRequester.swift in Sources */,
 				55DECC3F29BFEACB00D5C802 /* MockVerifiableCredentialHelper.swift in Sources */,
+				2ABE2AF6649EAD4BF92778D2 /* StatusCheckServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3043D92B5611982D88E50670 /* CollectionsQueryPostOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A32A62BBF9D9B5ECBC2483E /* CollectionsQueryPostOperation.swift */; };
 		5507A40B2BD99986003646EE /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 5507A40A2BD99986003646EE /* PrivacyInfo.xcprivacy */; };
 		550A913D29930D970014D030 /* MockRawRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550A913C29930D970014D030 /* MockRawRequest.swift */; };
 		550A916F299310D40014D030 /* OpenIdRequestProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550A9157299310D40014D030 /* OpenIdRequestProcessor.swift */; };
@@ -572,6 +573,9 @@
 		55F01CD42ACE100B000794B4 /* ES256PublicKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F01CD32ACE100B000794B4 /* ES256PublicKeyTests.swift */; };
 		55FE707A2B72E7C600CC3018 /* OpenId4VCIProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FE70792B72E7C600CC3018 /* OpenId4VCIProcessor.swift */; };
 		55FE70822B730D1500CC3018 /* CredentialMetadataFetchOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55FE70812B730D1500CC3018 /* CredentialMetadataFetchOperation.swift */; };
+		698539E4DEB6CB2E318A8E2E /* StatusListTokenValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A3C23380EEFA71F9985A36 /* StatusListTokenValidator.swift */; };
+		76673F52A83260037A779DB2 /* StatusListCredentialFetchOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1B8B2800AA79BAED7CC9B7 /* StatusListCredentialFetchOperation.swift */; };
+		971114FD8BFAAF985FF3B982 /* Data+Gzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BBF26C3A69F9DDE090BC28 /* Data+Gzip.swift */; };
 		A48C1EB62B8FF19000545FF6 /* VerifiedIdSerializing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48C1EB52B8FF19000545FF6 /* VerifiedIdSerializing.swift */; };
 		A497435B2B8EA367004851C2 /* VerifiedIdPartialRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A497435A2B8EA367004851C2 /* VerifiedIdPartialRequest.swift */; };
 		A497435F2B8EB29B004851C2 /* PresentationExchangeRequirement.swift in Sources */ = {isa = PBXBuildFile; fileRef = A497435E2B8EB29B004851C2 /* PresentationExchangeRequirement.swift */; };
@@ -583,6 +587,9 @@
 		A4DC99822B7D29FF008F389F /* PresentationExchangeVerifiedIdRequirementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4DC99812B7D29FF008F389F /* PresentationExchangeVerifiedIdRequirementTests.swift */; };
 		A4DF2BF02E9EF8A4000AE314 /* MatchSubjectCryptoRequirement.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4DF2BEE2E9EF89B000AE314 /* MatchSubjectCryptoRequirement.swift */; };
 		A4F39A8B2B91571E005C12FC /* ExtensionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4F39A8A2B91571E005C12FC /* ExtensionConfiguration.swift */; };
+		D7FE11CA33A9C94CC671D210 /* VerifiedIdStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB866B76909C2AD2B0D52847 /* VerifiedIdStatus.swift */; };
+		DDE22801239649B008402D34 /* CredentialStatusDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7A381EDDE78BCFE7BC8C85B /* CredentialStatusDescriptor.swift */; };
+		EF51B40753AD76C1021EA2C8 /* StatusCheckService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A71E43EA44E649970BFF4A4 /* StatusCheckService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -610,6 +617,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2A32A62BBF9D9B5ECBC2483E /* CollectionsQueryPostOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CollectionsQueryPostOperation.swift; path = StatusCheck/CollectionsQueryPostOperation.swift; sourceTree = "<group>"; };
 		5507A40A2BD99986003646EE /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		550A913C29930D970014D030 /* MockRawRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRawRequest.swift; sourceTree = "<group>"; };
 		550A9157299310D40014D030 /* OpenIdRequestProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenIdRequestProcessor.swift; sourceTree = "<group>"; };
@@ -1179,6 +1187,9 @@
 		55F01CD32ACE100B000794B4 /* ES256PublicKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ES256PublicKeyTests.swift; sourceTree = "<group>"; };
 		55FE70792B72E7C600CC3018 /* OpenId4VCIProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenId4VCIProcessor.swift; sourceTree = "<group>"; };
 		55FE70812B730D1500CC3018 /* CredentialMetadataFetchOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialMetadataFetchOperation.swift; sourceTree = "<group>"; };
+		56A3C23380EEFA71F9985A36 /* StatusListTokenValidator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StatusListTokenValidator.swift; path = StatusCheck/StatusListTokenValidator.swift; sourceTree = "<group>"; };
+		7A71E43EA44E649970BFF4A4 /* StatusCheckService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StatusCheckService.swift; path = StatusCheck/StatusCheckService.swift; sourceTree = "<group>"; };
+		84BBF26C3A69F9DDE090BC28 /* Data+Gzip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Data+Gzip.swift"; sourceTree = "<group>"; };
 		A48C1EB52B8FF19000545FF6 /* VerifiedIdSerializing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedIdSerializing.swift; sourceTree = "<group>"; };
 		A497435A2B8EA367004851C2 /* VerifiedIdPartialRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedIdPartialRequest.swift; sourceTree = "<group>"; };
 		A497435E2B8EB29B004851C2 /* PresentationExchangeRequirement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationExchangeRequirement.swift; sourceTree = "<group>"; };
@@ -1190,6 +1201,9 @@
 		A4DC99812B7D29FF008F389F /* PresentationExchangeVerifiedIdRequirementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationExchangeVerifiedIdRequirementTests.swift; sourceTree = "<group>"; };
 		A4DF2BEE2E9EF89B000AE314 /* MatchSubjectCryptoRequirement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchSubjectCryptoRequirement.swift; sourceTree = "<group>"; };
 		A4F39A8A2B91571E005C12FC /* ExtensionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionConfiguration.swift; sourceTree = "<group>"; };
+		A7A381EDDE78BCFE7BC8C85B /* CredentialStatusDescriptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CredentialStatusDescriptor.swift; path = StatusCheck/CredentialStatusDescriptor.swift; sourceTree = "<group>"; };
+		CB866B76909C2AD2B0D52847 /* VerifiedIdStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VerifiedIdStatus.swift; sourceTree = "<group>"; };
+		EE1B8B2800AA79BAED7CC9B7 /* StatusListCredentialFetchOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StatusListCredentialFetchOperation.swift; path = StatusCheck/StatusListCredentialFetchOperation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1416,6 +1430,7 @@
 				550E3207298B0EA4004E7716 /* VerifiedIdClientBuilder.swift */,
 				55508A6E2A3BCB5000186885 /* WalletLibraryVersion.swift */,
 				552E5095293E6AB200868F47 /* WalletLibrary.h */,
+				B05C3D32C2B12EF07692041A /* StatusCheck */,
 			);
 			path = WalletLibrary;
 			sourceTree = "<group>";
@@ -3160,6 +3175,7 @@
 				55BA2DCE29CDFA1A00BB8207 /* VerifiedIdDecoder.swift */,
 				55BA2DCF29CDFA1A00BB8207 /* VerifiedIdEncoder.swift */,
 				5524A5F629D634BC00C5F18D /* VerifiedIdLogo.swift */,
+				CB866B76909C2AD2B0D52847 /* VerifiedIdStatus.swift */,
 			);
 			path = VerifiedId;
 			sourceTree = "<group>";
@@ -3277,6 +3293,7 @@
 				5534E663294A0B28005D0765 /* Mappings */,
 				55265A3C2B619DBB00BAD6A2 /* Data+Base64URLEncoding.swift */,
 				555FB20A2B757A9E00EE14BD /* Decodable+PropertyValidation.swift */,
+				84BBF26C3A69F9DDE090BC28 /* Data+Gzip.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3325,6 +3342,18 @@
 				A4D9F9C62B7AF2BF006D074E /* RequestProcessorExtendable.swift */,
 			);
 			path = ProcessorExtensions;
+			sourceTree = "<group>";
+		};
+		B05C3D32C2B12EF07692041A /* StatusCheck */ = {
+			isa = PBXGroup;
+			children = (
+				A7A381EDDE78BCFE7BC8C85B /* CredentialStatusDescriptor.swift */,
+				EE1B8B2800AA79BAED7CC9B7 /* StatusListCredentialFetchOperation.swift */,
+				56A3C23380EEFA71F9985A36 /* StatusListTokenValidator.swift */,
+				7A71E43EA44E649970BFF4A4 /* StatusCheckService.swift */,
+				2A32A62BBF9D9B5ECBC2483E /* CollectionsQueryPostOperation.swift */,
+			);
+			name = StatusCheck;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -3851,6 +3880,13 @@
 				5552D44529EF4A8100B40302 /* NoRetry.swift in Sources */,
 				5552D3F129EF48E200B40302 /* PresentationResponse.swift in Sources */,
 				55E2F07D2995561E0008010D /* OpenIdPresentationRequest.swift in Sources */,
+				D7FE11CA33A9C94CC671D210 /* VerifiedIdStatus.swift in Sources */,
+				971114FD8BFAAF985FF3B982 /* Data+Gzip.swift in Sources */,
+				DDE22801239649B008402D34 /* CredentialStatusDescriptor.swift in Sources */,
+				76673F52A83260037A779DB2 /* StatusListCredentialFetchOperation.swift in Sources */,
+				698539E4DEB6CB2E318A8E2E /* StatusListTokenValidator.swift in Sources */,
+				EF51B40753AD76C1021EA2C8 /* StatusCheckService.swift in Sources */,
+				3043D92B5611982D88E50670 /* CollectionsQueryPostOperation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WalletLibrary/WalletLibrary/Extensions/Data+Gzip.swift
+++ b/WalletLibrary/WalletLibrary/Extensions/Data+Gzip.swift
@@ -10,11 +10,9 @@ extension Data {
 
     /// Inflates a GZIP (RFC 1952) payload, as used by the StatusList2021 `encodedList`.
     ///
-    /// Apple's `Compression` framework only inflates a raw DEFLATE stream, so this strips the
-    /// gzip header (including the optional FEXTRA / FNAME / FCOMMENT / FHCRC fields) and the
-    /// 8-byte trailer, then streams the DEFLATE payload through `COMPRESSION_ZLIB`. Returns
-    /// `nil` for any malformed input rather than throwing, so callers can treat a bad list as
-    /// an indeterminate (`.unknown`) status.
+    /// Apple's `Compression` framework inflates only a raw DEFLATE stream, so this strips the gzip
+    /// header (including the optional FEXTRA / FNAME / FCOMMENT / FHCRC fields) and the 8-byte trailer,
+    /// then streams the DEFLATE payload through `COMPRESSION_ZLIB`. Returns `nil` for malformed input.
     func gunzipped() -> Data? {
         // Smallest possible gzip stream: 10-byte header + 8-byte trailer.
         guard count >= 18,

--- a/WalletLibrary/WalletLibrary/Extensions/Data+Gzip.swift
+++ b/WalletLibrary/WalletLibrary/Extensions/Data+Gzip.swift
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import Compression
+import Foundation
+
+extension Data {
+
+    /// Inflates a GZIP (RFC 1952) payload, as used by the StatusList2021 `encodedList`.
+    ///
+    /// Apple's `Compression` framework only inflates a raw DEFLATE stream, so this strips the
+    /// gzip header (including the optional FEXTRA / FNAME / FCOMMENT / FHCRC fields) and the
+    /// 8-byte trailer, then streams the DEFLATE payload through `COMPRESSION_ZLIB`. Returns
+    /// `nil` for any malformed input rather than throwing, so callers can treat a bad list as
+    /// an indeterminate (`.unknown`) status.
+    func gunzipped() -> Data? {
+        // Smallest possible gzip stream: 10-byte header + 8-byte trailer.
+        guard count >= 18,
+              self[startIndex] == 0x1f,
+              self[startIndex + 1] == 0x8b,
+              self[startIndex + 2] == 0x08 else {
+            return nil
+        }
+
+        let flags = self[startIndex + 3]
+        var cursor = startIndex + 10
+
+        // FEXTRA: 2-byte little-endian length, then that many bytes.
+        if flags & 0x04 != 0 {
+            guard cursor + 2 <= endIndex else { return nil }
+            let extraLength = Int(self[cursor]) | (Int(self[cursor + 1]) << 8)
+            cursor += 2 + extraLength
+        }
+        // FNAME / FCOMMENT: zero-terminated strings.
+        if flags & 0x08 != 0 { cursor = indexAfterZeroByte(from: cursor) }
+        if flags & 0x10 != 0 { cursor = indexAfterZeroByte(from: cursor) }
+        // FHCRC: 2-byte header CRC.
+        if flags & 0x02 != 0 { cursor += 2 }
+
+        // Need at least the 8-byte trailer after the DEFLATE payload.
+        guard cursor <= endIndex - 8, cursor >= startIndex else { return nil }
+        let deflatePayload = subdata(in: cursor..<(endIndex - 8))
+        guard !deflatePayload.isEmpty else { return nil }
+
+        return Self.inflateRawDeflate(deflatePayload)
+    }
+
+    /// Returns the index just past the next zero byte at or after `from`, clamped to `endIndex`.
+    private func indexAfterZeroByte(from: Int) -> Int {
+        var cursor = from
+        while cursor < endIndex, self[cursor] != 0 { cursor += 1 }
+        return cursor + 1
+    }
+
+    /// Streams a raw DEFLATE buffer through `COMPRESSION_ZLIB`, growing the output as needed.
+    private static func inflateRawDeflate(_ deflatePayload: Data) -> Data? {
+        var stream = compression_stream(dst_ptr: UnsafeMutablePointer<UInt8>(bitPattern: 1)!,
+                                        dst_size: 0,
+                                        src_ptr: UnsafeMutablePointer<UInt8>(bitPattern: 1)!,
+                                        src_size: 0,
+                                        state: nil)
+        guard compression_stream_init(&stream, COMPRESSION_STREAM_DECODE, COMPRESSION_ZLIB)
+                == COMPRESSION_STATUS_OK else {
+            return nil
+        }
+        defer { compression_stream_destroy(&stream) }
+
+        let bufferSize = 32_768
+        let destinationBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { destinationBuffer.deallocate() }
+
+        var output = Data()
+        let result: Data? = deflatePayload.withUnsafeBytes { (rawBuffer: UnsafeRawBufferPointer) -> Data? in
+            guard let baseAddress = rawBuffer.bindMemory(to: UInt8.self).baseAddress else { return nil }
+            stream.src_ptr = baseAddress
+            stream.src_size = deflatePayload.count
+
+            repeat {
+                stream.dst_ptr = destinationBuffer
+                stream.dst_size = bufferSize
+
+                let status = compression_stream_process(&stream, Int32(COMPRESSION_STREAM_FINALIZE.rawValue))
+                switch status {
+                case COMPRESSION_STATUS_OK, COMPRESSION_STATUS_END:
+                    output.append(destinationBuffer, count: bufferSize - stream.dst_size)
+                    if status == COMPRESSION_STATUS_END { return output }
+                default:
+                    return nil
+                }
+            } while true
+        }
+        return result
+    }
+}

--- a/WalletLibrary/WalletLibrary/Extensions/Data+Gzip.swift
+++ b/WalletLibrary/WalletLibrary/Extensions/Data+Gzip.swift
@@ -8,11 +8,18 @@ import Foundation
 
 extension Data {
 
+    /// Upper bound on `gunzipped()` output. DEFLATE reaches ~1000:1 ratios, so an attacker-supplied
+    /// `encodedList` could inflate to gigabytes and OOM-crash the wallet. A StatusList2021 bitstring is
+    /// tiny (the W3C minimum is 16 KB; this 10 MB cap covers ~80 million credentials), so a payload
+    /// exceeding it is malformed or hostile and degrades to `nil` (caller treats as `.unknown`).
+    static let maxGunzippedByteCount = 10 * 1024 * 1024
+
     /// Inflates a GZIP (RFC 1952) payload, as used by the StatusList2021 `encodedList`.
     ///
     /// Apple's `Compression` framework inflates only a raw DEFLATE stream, so this strips the gzip
     /// header (including the optional FEXTRA / FNAME / FCOMMENT / FHCRC fields) and the 8-byte trailer,
-    /// then streams the DEFLATE payload through `COMPRESSION_ZLIB`. Returns `nil` for malformed input.
+    /// then streams the DEFLATE payload through `COMPRESSION_ZLIB`. Returns `nil` for malformed input or
+    /// when the inflated size exceeds `maxGunzippedByteCount` (zip-bomb guard).
     func gunzipped() -> Data? {
         // Smallest possible gzip stream: 10-byte header + 8-byte trailer.
         guard count >= 18,
@@ -83,6 +90,7 @@ extension Data {
                 switch status {
                 case COMPRESSION_STATUS_OK, COMPRESSION_STATUS_END:
                     output.append(destinationBuffer, count: bufferSize - stream.dst_size)
+                    if output.count > Data.maxGunzippedByteCount { return nil }
                     if status == COMPRESSION_STATUS_END { return output }
                 default:
                     return nil

--- a/WalletLibrary/WalletLibrary/StatusCheck/CollectionsQueryPostOperation.swift
+++ b/WalletLibrary/WalletLibrary/StatusCheck/CollectionsQueryPostOperation.swift
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import Foundation
+
+/**
+ * POSTs a CollectionsQuery message to an issuer's IdentityHub to fetch a StatusList2021 credential.
+ *
+ * Used by older Entra Verified ID credentials whose `credentialStatus` is a `urn:uuid:` or
+ * `did:`-relative reference rather than a direct HTTPS URL. The body is the pre-encoded
+ * CollectionsQuery JSON; the response (a hub envelope) is returned verbatim as `Data`.
+ */
+struct CollectionsQueryPostOperation: WalletLibraryPostOperation {
+
+    typealias RequestBody = Data
+    typealias ResponseBody = Data
+    typealias Encoder = StatusListRawDataEncoder
+    typealias Decoder = StatusListResponseDecoder
+
+    var encoder = StatusListRawDataEncoder()
+    var decoder = StatusListResponseDecoder()
+    let urlSession: URLSession
+    var urlRequest: URLRequest
+    var correlationVector: VerifiedIdCorrelationHeader?
+
+    init(requestBody: Data,
+         url: URL,
+         additionalHeaders: [String: String]?,
+         urlSession: URLSession,
+         correlationVector: VerifiedIdCorrelationHeader?) throws {
+        self.urlSession = urlSession
+        self.correlationVector = correlationVector
+        self.urlRequest = URLRequest(url: url)
+        self.urlRequest.httpMethod = Constants.POST
+        self.urlRequest.httpBody = requestBody
+        self.urlRequest.setValue(Constants.JSON, forHTTPHeaderField: Constants.CONTENT_TYPE)
+        addHeadersToURLRequest(headers: additionalHeaders)
+    }
+}
+
+/// Passes the pre-encoded request body through unchanged; the CollectionsQuery JSON is built by hand.
+struct StatusListRawDataEncoder: Encoding {
+    func encode(value: Data) throws -> Data {
+        return value
+    }
+}

--- a/WalletLibrary/WalletLibrary/StatusCheck/CredentialStatusDescriptor.swift
+++ b/WalletLibrary/WalletLibrary/StatusCheck/CredentialStatusDescriptor.swift
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import Foundation
+
+/**
+ * The `credentialStatus` entry embedded in a Verifiable Credential JWT.
+ *
+ * Normalises the Entra / W3C variants — `StatusList2021Entry`, `RevocationList2021Status` (both use
+ * `statusListIndex` / `statusListCredential`) and `RevocationList2020Status` (uses
+ * `revocationListIndex` / `revocationListCredential`) — behind `effectiveStatusListCredential` and
+ * `effectiveStatusListIndex`, so callers don't branch on `type`.
+ */
+struct CredentialStatusDescriptor: Equatable {
+
+    let id: String
+    let type: String
+    let statusPurpose: String
+    let statusListIndex: Int
+    let statusListCredential: String
+    let revocationListIndex: Int
+    let revocationListCredential: String
+
+    /// URL of the status list credential, normalised across the known type variants.
+    var effectiveStatusListCredential: String {
+        statusListCredential.isEmpty ? revocationListCredential : statusListCredential
+    }
+
+    /// Bit index within the status list bitstring, normalised across the known type variants.
+    var effectiveStatusListIndex: Int {
+        statusListCredential.isEmpty ? revocationListIndex : statusListIndex
+    }
+
+    /// Builds a descriptor from a parsed `credentialStatus` JSON object. Returns `nil` when the entry
+    /// carries neither a status list reference nor an id, i.e. there is nothing to check.
+    init?(json: [String: Any]) {
+        self.id = json["id"] as? String ?? ""
+        self.type = (json["type"] as? String) ?? (json["type"] as? [String])?.first ?? ""
+        self.statusPurpose = json["statusPurpose"] as? String ?? ""
+        self.statusListIndex = CredentialStatusDescriptor.intValue(json["statusListIndex"])
+        self.statusListCredential = json["statusListCredential"] as? String ?? ""
+        self.revocationListIndex = CredentialStatusDescriptor.intValue(json["revocationListIndex"])
+        self.revocationListCredential = json["revocationListCredential"] as? String ?? ""
+
+        if effectiveStatusListCredential.isEmpty && id.isEmpty {
+            return nil
+        }
+    }
+
+    /// Status list indices appear as either a JSON number or a numeric string across issuers.
+    private static func intValue(_ value: Any?) -> Int {
+        switch value {
+        case let int as Int: return int
+        case let number as NSNumber: return number.intValue
+        case let string as String: return Int(string) ?? 0
+        case let double as Double: return Int(double)
+        default: return 0
+        }
+    }
+}

--- a/WalletLibrary/WalletLibrary/StatusCheck/CredentialStatusDescriptor.swift
+++ b/WalletLibrary/WalletLibrary/StatusCheck/CredentialStatusDescriptor.swift
@@ -19,34 +19,48 @@ struct CredentialStatusDescriptor: Equatable {
     let type: String
     let statusPurpose: String
     let statusListIndex: Int
-    let statusListCredential: String
+    let statusListCredential: String?
     let revocationListIndex: Int
-    let revocationListCredential: String
 
-    /// URL of the status list credential, normalised across the known type variants.
-    var effectiveStatusListCredential: String {
-        statusListCredential.isEmpty ? revocationListCredential : statusListCredential
+    /// Older Entra field name for the same concept as `statusListCredential`: the URL of the issuer's
+    /// status bitstring credential. The W3C StatusList2021 spec (§5.1, `StatusList2021Entry`) renamed
+    /// `revocationListCredential` to `statusListCredential`; both are accepted for backward
+    /// compatibility and normalised behind `effectiveStatusListCredential`.
+    let revocationListCredential: String?
+
+    /// URL of the status list credential, normalised across the known type variants, or `nil` when the
+    /// entry references neither.
+    var effectiveStatusListCredential: String? {
+        statusListCredential ?? revocationListCredential
     }
 
     /// Bit index within the status list bitstring, normalised across the known type variants.
     var effectiveStatusListIndex: Int {
-        statusListCredential.isEmpty ? revocationListIndex : statusListIndex
+        statusListCredential != nil ? statusListIndex : revocationListIndex
     }
 
     /// Builds a descriptor from a parsed `credentialStatus` JSON object. Returns `nil` when the entry
-    /// carries neither a status list reference nor an id, i.e. there is nothing to check.
+    /// carries neither a status list reference nor an id, i.e. there is nothing to check. Empty-string
+    /// credential URLs are normalised to `nil` so the `statusListCredential` / `revocationListCredential`
+    /// fallback behaves the same whether a field is absent or blank.
     init?(json: [String: Any]) {
         self.id = json["id"] as? String ?? ""
         self.type = (json["type"] as? String) ?? (json["type"] as? [String])?.first ?? ""
         self.statusPurpose = json["statusPurpose"] as? String ?? ""
         self.statusListIndex = CredentialStatusDescriptor.intValue(json["statusListIndex"])
-        self.statusListCredential = json["statusListCredential"] as? String ?? ""
+        self.statusListCredential = CredentialStatusDescriptor.nonEmpty(json["statusListCredential"])
         self.revocationListIndex = CredentialStatusDescriptor.intValue(json["revocationListIndex"])
-        self.revocationListCredential = json["revocationListCredential"] as? String ?? ""
+        self.revocationListCredential = CredentialStatusDescriptor.nonEmpty(json["revocationListCredential"])
 
-        if effectiveStatusListCredential.isEmpty && id.isEmpty {
+        if effectiveStatusListCredential == nil && id.isEmpty {
             return nil
         }
+    }
+
+    /// Reads a non-empty string value, mapping a missing or blank field to `nil`.
+    private static func nonEmpty(_ value: Any?) -> String? {
+        guard let string = value as? String, !string.isEmpty else { return nil }
+        return string
     }
 
     /// Status list indices appear as either a JSON number or a numeric string across issuers.

--- a/WalletLibrary/WalletLibrary/StatusCheck/StatusCheckService.swift
+++ b/WalletLibrary/WalletLibrary/StatusCheck/StatusCheckService.swift
@@ -102,12 +102,17 @@ class StatusCheckService {
 
     /// Resolves the status list credential to a fetchable HTTPS URL: a direct `https://` URL, or a
     /// `did:web:` reference resolved through its DID document's service endpoint. Returns `nil` for
-    /// anything else (caller falls back to the IdentityHub path).
+    /// anything else — including a `did:web:` reference carrying a `queries` parameter, which is the
+    /// IdentityHub CollectionsQuery (POST) form — so the caller falls back to the IdentityHub path
+    /// instead of GETting an endpoint that only answers POST.
     private func resolveStatusListURL(_ raw: String) async -> URL? {
         if raw.hasPrefix("https://") {
             return StatusCheckService.isWellFormedHttpsURL(raw) ? URL(string: raw) : nil
         }
         if raw.hasPrefix("did:web:") {
+            if StatusCheckService.didURLQueryParameter(raw, key: "queries") != nil {
+                return nil
+            }
             return await resolveDidWebURL(raw)
         }
         return nil

--- a/WalletLibrary/WalletLibrary/StatusCheck/StatusCheckService.swift
+++ b/WalletLibrary/WalletLibrary/StatusCheck/StatusCheckService.swift
@@ -33,6 +33,12 @@ class StatusCheckService {
         self.dateProvider = dateProvider
     }
 
+    /// W3C StatusList2021 `statusPurpose` values. A credential's declared purpose must match the
+    /// fetched status list's purpose before its bit is trusted, and the purpose selects whether a
+    /// set bit means `.suspended` or `.revoked`.
+    static let statusPurposeRevocation = "revocation"
+    static let statusPurposeSuspension = "suspension"
+
     func checkStatus(of verifiedId: VerifiedId) async -> VerifiedIdStatus {
         if let expiresOn = verifiedId.expiresOn, expiresOn < dateProvider() {
             return .expired
@@ -43,6 +49,7 @@ class StatusCheckService {
         }
 
         guard let descriptor = StatusCheckService.parseCredentialStatus(from: credential.raw) else {
+            configuration.logger.logVerbose(message: "StatusCheck: credential has no parseable credentialStatus; treating as no status endpoint.")
             return .noStatusEndpoint
         }
 
@@ -54,15 +61,20 @@ class StatusCheckService {
                                          issuerDid: String) async -> VerifiedIdStatus {
         let statusListCredential = descriptor.effectiveStatusListCredential
 
-        if let url = await resolveStatusListURL(statusListCredential) {
+        if let statusListCredential = statusListCredential,
+           let url = await resolveStatusListURL(statusListCredential) {
             return await checkDirectStatusList(url: url, descriptor: descriptor, issuerDid: issuerDid)
         }
 
-        if statusListCredential.hasPrefix("did:") || descriptor.id.hasPrefix("urn:uuid:") {
-            guard !issuerDid.isEmpty else { return .unknown }
+        if statusListCredential?.hasPrefix("did:") == true || descriptor.id.hasPrefix("urn:uuid:") {
+            guard !issuerDid.isEmpty else {
+                configuration.logger.logVerbose(message: "StatusCheck: IdentityHub status list requires an issuer DID, but none was present.")
+                return .unknown
+            }
             return await checkStatusViaIdentityHub(descriptor: descriptor, issuerDid: issuerDid)
         }
 
+        configuration.logger.logVerbose(message: "StatusCheck: credential status uses an unsupported status list reference.")
         return .unknown
     }
 
@@ -76,12 +88,14 @@ class StatusCheckService {
                                                                         StatusListCredentialFetchOperation.self)
             guard let jwt = StatusCheckService.compactJws(from: responseData),
                   let statusList = await verifyAndExtractStatusList(fromJws: jwt, issuerDid: issuerDid) else {
+                configuration.logger.logVerbose(message: "StatusCheck: status list credential could not be parsed or verified.")
                 return .unknown
             }
             return StatusCheckService.evaluate(statusList: statusList,
                                                descriptor: descriptor,
                                                bitIndex: descriptor.effectiveStatusListIndex)
         } catch {
+            configuration.logger.logVerbose(message: "StatusCheck: failed to fetch status list credential.")
             return .unknown
         }
     }
@@ -107,6 +121,12 @@ class StatusCheckService {
         guard let services = await resolveDIDDocumentServices(did: did),
               let service = StatusCheckService.findService(services, named: serviceName),
               let endpoint = StatusCheckService.serviceEndpointURL(from: service) else {
+            configuration.logger.logVerbose(message: "StatusCheck: could not resolve a did:web service endpoint for the status list.")
+            return nil
+        }
+
+        guard StatusCheckService.isWellFormedHttpsURL(endpoint) else {
+            configuration.logger.logVerbose(message: "StatusCheck: resolved did:web status list endpoint is not a well-formed HTTPS URL.")
             return nil
         }
 
@@ -129,10 +149,20 @@ class StatusCheckService {
         }
         let bitIndex = resolveStatusListBitIndex(descriptor: descriptor)
 
-        guard let services = await resolveDIDDocumentServices(did: issuerDid),
+        // Resolve the issuer's DID document once and reuse it both to locate the IdentityHub endpoint
+        // (from the raw `instances` form the typed model omits) and to verify the status list
+        // signature, avoiding a second fetch of the same document inside the validator.
+        let issuerDocument = await resolveDIDDocument(did: issuerDid)
+
+        guard let services = issuerDocument.services,
               let hubService = StatusCheckService.findService(services, named: "IdentityHub"),
-              let hubEndpoint = StatusCheckService.serviceEndpointURL(from: hubService),
-              let hubURL = URL(string: hubEndpoint) else {
+              let hubEndpoint = StatusCheckService.serviceEndpointURL(from: hubService) else {
+            configuration.logger.logVerbose(message: "StatusCheck: issuer DID document has no IdentityHub service endpoint.")
+            return .unknown
+        }
+
+        guard StatusCheckService.isWellFormedHttpsURL(hubEndpoint), let hubURL = URL(string: hubEndpoint) else {
+            configuration.logger.logVerbose(message: "StatusCheck: IdentityHub endpoint is not a well-formed HTTPS URL.")
             return .unknown
         }
 
@@ -142,19 +172,26 @@ class StatusCheckService {
                                                                        url: hubURL,
                                                                        CollectionsQueryPostOperation.self)
             guard let responseBody = String(data: responseData, encoding: .utf8) else {
+                configuration.logger.logVerbose(message: "StatusCheck: IdentityHub response was not valid UTF-8.")
                 return .unknown
             }
 
-            var statusList = await verifyAndExtractStatusList(fromJws: responseBody, issuerDid: issuerDid)
+            var statusList = await verifyAndExtractStatusList(fromJws: responseBody,
+                                                              issuerDid: issuerDid,
+                                                              issuerDocument: issuerDocument.document)
             if statusList == nil {
-                statusList = await extractStatusListFromCollectionsResponse(responseBody, issuerDid: issuerDid)
+                statusList = await extractStatusListFromCollectionsResponse(responseBody,
+                                                                            issuerDid: issuerDid,
+                                                                            issuerDocument: issuerDocument.document)
             }
 
             guard let resolved = statusList else {
+                configuration.logger.logVerbose(message: "StatusCheck: no verifiable status list found in IdentityHub response.")
                 return .unknown
             }
             return StatusCheckService.evaluate(statusList: resolved, descriptor: descriptor, bitIndex: bitIndex)
         } catch {
+            configuration.logger.logVerbose(message: "StatusCheck: failed to query IdentityHub for the status list.")
             return .unknown
         }
     }
@@ -167,17 +204,28 @@ class StatusCheckService {
             return body.components(separatedBy: "?").first
         }
 
-        let statusCredential = descriptor.effectiveStatusListCredential
-        if statusCredential.hasPrefix("did:") {
-            guard let encodedQueries = StatusCheckService.didURLQueryParameter(statusCredential, key: "queries"),
-                  let decoded = Data(base64URLEncoded: encodedQueries),
-                  let array = try? JSONSerialization.jsonObject(with: decoded) as? [[String: Any]],
-                  let objectId = array.first?["objectId"] as? String else {
-                return nil
-            }
-            return objectId
+        guard let statusCredential = descriptor.effectiveStatusListCredential,
+              statusCredential.hasPrefix("did:") else {
+            return nil
         }
-        return nil
+        guard let encodedQueries = StatusCheckService.didURLQueryParameter(statusCredential, key: "queries") else {
+            configuration.logger.logVerbose(message: "StatusCheck: IdentityHub credential is missing a 'queries' parameter.")
+            return nil
+        }
+        guard let decoded = Data(base64URLEncoded: encodedQueries) else {
+            configuration.logger.logVerbose(message: "StatusCheck: IdentityHub 'queries' parameter is not valid base64url.")
+            return nil
+        }
+        guard let array = try? JSONSerialization.jsonObject(with: decoded) as? [[String: Any]],
+              let firstEntry = array.first else {
+            configuration.logger.logVerbose(message: "StatusCheck: IdentityHub 'queries' did not decode to a non-empty array.")
+            return nil
+        }
+        guard let objectId = firstEntry["objectId"] as? String else {
+            configuration.logger.logVerbose(message: "StatusCheck: IdentityHub query entry is missing 'objectId'.")
+            return nil
+        }
+        return objectId
     }
 
     /// Bit index from the `urn:uuid:...?bit-index=N` id when present, else the descriptor's index.
@@ -193,7 +241,8 @@ class StatusCheckService {
     /// Extracts the status list from a CollectionsQuery envelope: each `replies[].entries[].data` is a
     /// base64url-encoded JWT, decoded and verified via `verifyAndExtractStatusList` (raw value tried too).
     private func extractStatusListFromCollectionsResponse(_ responseBody: String,
-                                                          issuerDid: String) async -> (encodedList: String, statusPurpose: String)? {
+                                                          issuerDid: String,
+                                                          issuerDocument: IdentifierDocument? = nil) async -> (encodedList: String, statusPurpose: String)? {
         guard let data = responseBody.data(using: .utf8),
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let replies = root["replies"] as? [[String: Any]] else {
@@ -205,10 +254,10 @@ class StatusCheckService {
             for entry in entries {
                 guard let entryData = entry["data"] as? String else { continue }
                 if let decoded = StatusCheckService.base64DecodeToString(entryData),
-                   let result = await verifyAndExtractStatusList(fromJws: decoded, issuerDid: issuerDid) {
+                   let result = await verifyAndExtractStatusList(fromJws: decoded, issuerDid: issuerDid, issuerDocument: issuerDocument) {
                     return result
                 }
-                if let result = await verifyAndExtractStatusList(fromJws: entryData, issuerDid: issuerDid) {
+                if let result = await verifyAndExtractStatusList(fromJws: entryData, issuerDid: issuerDid, issuerDocument: issuerDocument) {
                     return result
                 }
             }
@@ -222,13 +271,21 @@ class StatusCheckService {
     /// `encodedList` / `statusPurpose`. Returns `nil` for an unsigned body or any failed check, so the
     /// SDK never reads bits from unverified data.
     private func verifyAndExtractStatusList(fromJws jws: String,
-                                            issuerDid: String) async -> (encodedList: String, statusPurpose: String)? {
+                                            issuerDid: String,
+                                            issuerDocument: IdentifierDocument? = nil) async -> (encodedList: String, statusPurpose: String)? {
         guard let token = JwsToken<StatusListClaims>(from: jws) else {
             return nil
         }
         do {
-            try await validator.validate(token, expectedIssuerDid: issuerDid, now: dateProvider())
+            try await validator.validate(token,
+                                         expectedIssuerDid: issuerDid,
+                                         now: dateProvider(),
+                                         preResolvedDocument: issuerDocument)
+        } catch let error as StatusListValidationError {
+            configuration.logger.logVerbose(message: "StatusCheck: status list token failed validation (\(error)).")
+            return nil
         } catch {
+            configuration.logger.logVerbose(message: "StatusCheck: status list token validation could not complete.")
             return nil
         }
         return StatusCheckService.extractStatusListInfo(fromJws: jws)
@@ -253,7 +310,7 @@ class StatusCheckService {
         if !isFlagged {
             return .valid
         }
-        return statusList.statusPurpose == "suspension" ? .suspended : .revoked
+        return statusList.statusPurpose == statusPurposeSuspension ? .suspended : .revoked
     }
 
     /// Parses the credential's own `credentialStatus` entry from the raw VC payload. The decoded
@@ -296,16 +353,13 @@ class StatusCheckService {
             return nil
         }
 
-        let statusPurpose = subject["statusPurpose"] as? String ?? "revocation"
+        let statusPurpose = subject["statusPurpose"] as? String ?? statusPurposeRevocation
         return (encodedList, statusPurpose)
     }
 
-    /// Reads the bit at [index] using least-significant-bit-first ordering (index 0 = LSB of byte 0),
-    /// i.e. `1 << (index % 8)`. This matches Entra's status list encoding; MSB-first ordering would
-    /// break revocation detection for any index that is not a multiple of 8.
-    ///
-    /// Returns `true` if the bit is set (revoked/suspended), `false` if clear (valid), or `nil` when
-    /// [index] is outside the bitstring (caller treats as `.unknown`).
+    /// Reads the bit at [index] least-significant-bit-first (index 0 = LSB of byte 0), matching Entra's
+    /// status list encoding. Returns `true` if set (revoked/suspended), `false` if clear (valid), or
+    /// `nil` when [index] is outside the bitstring.
     static func checkBit(_ bitstring: Data, index: Int) -> Bool? {
         guard index >= 0 else { return nil }
         let byteIndex = index / 8
@@ -403,14 +457,32 @@ class StatusCheckService {
         return nil
     }
 
-    private func resolveDIDDocumentServices(did: String) async -> [[String: Any]]? {
-        guard let url = StatusCheckService.discoveryURL(for: did),
-              let data = try? await configuration.networking.fetch(url: url, StatusListCredentialFetchOperation.self),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return nil
+    /// Resolves a DID document once, returning the typed model (for signature verification) and the raw
+    /// `service` array (which preserves the IdentityHub `instances` endpoint the typed model omits).
+    /// One fetch serves both, so the IdentityHub path verifies signatures without re-fetching.
+    private func resolveDIDDocument(did: String) async -> (document: IdentifierDocument?, services: [[String: Any]]?) {
+        guard let url = StatusCheckService.discoveryURL(for: did) else {
+            configuration.logger.logVerbose(message: "StatusCheck: could not build a discovery URL to resolve the DID document.")
+            return (nil, nil)
         }
-        let didDocument = (json["didDocument"] as? [String: Any]) ?? json
-        return didDocument["service"] as? [[String: Any]]
+        guard let data = try? await configuration.networking.fetch(url: url, StatusListCredentialFetchOperation.self) else {
+            configuration.logger.logVerbose(message: "StatusCheck: failed to fetch the DID document from the discovery service.")
+            return (nil, nil)
+        }
+
+        let document = try? JSONDecoder().decode(DiscoveryServiceResponse.self, from: data).didDocument
+
+        var services: [[String: Any]]?
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            let didDocument = (json["didDocument"] as? [String: Any]) ?? json
+            services = didDocument["service"] as? [[String: Any]]
+        }
+        return (document, services)
+    }
+
+    /// Convenience over `resolveDIDDocument` for callers that only need the raw service array.
+    private func resolveDIDDocumentServices(did: String) async -> [[String: Any]]? {
+        return await resolveDIDDocument(did: did).services
     }
 
     private static func discoveryURL(for did: String) -> URL? {

--- a/WalletLibrary/WalletLibrary/StatusCheck/StatusCheckService.swift
+++ b/WalletLibrary/WalletLibrary/StatusCheck/StatusCheckService.swift
@@ -44,17 +44,53 @@ class StatusCheckService {
             return .expired
         }
 
-        guard let credential = verifiedId as? VCVerifiedId else {
-            return .noStatusEndpoint
+        // Both concrete VerifiedId types (`VCVerifiedId` and `OpenID4VCIVerifiedId`) conform to
+        // `InternalVerifiedId` and expose `.raw`, which is all the status parsing needs. Casting to the
+        // protocol — not a concrete type — keeps OpenID4VCI credentials in scope. An unrecognised type
+        // is `.unknown` (indeterminate), never `.noStatusEndpoint`, so a caller can't read it as "no
+        // status to check" and accept a credential whose status this SDK simply couldn't inspect.
+        guard let credential = verifiedId as? InternalVerifiedId else {
+            configuration.logger.logVerbose(message: "StatusCheck: unsupported VerifiedId type; status is indeterminate.")
+            return .unknown
         }
 
-        guard let descriptor = StatusCheckService.parseCredentialStatus(from: credential.raw) else {
+        let descriptors = StatusCheckService.parseCredentialStatuses(from: credential.raw)
+        guard !descriptors.isEmpty else {
             configuration.logger.logVerbose(message: "StatusCheck: credential has no parseable credentialStatus; treating as no status endpoint.")
             return .noStatusEndpoint
         }
 
         let issuerDid = credential.raw.content.iss ?? ""
-        return await fetchAndCheckStatusList(descriptor: descriptor, issuerDid: issuerDid)
+        return await evaluateAllStatusLists(descriptors: descriptors, issuerDid: issuerDid)
+    }
+
+    /// Evaluates every `credentialStatus` entry and combines them. StatusList2021 models revocation and
+    /// suspension as separate entries (distinct `statusPurpose`), so an issuer that supports both emits
+    /// two; checking only the first would let a set suspension bit be missed behind a clear revocation
+    /// bit. Revocation has priority (and short-circuits); an indeterminate entry downgrades the result
+    /// to `.unknown` rather than reporting a definitive `.valid` while ignoring data.
+    private func evaluateAllStatusLists(descriptors: [CredentialStatusDescriptor],
+                                        issuerDid: String) async -> VerifiedIdStatus {
+        var sawSuspended = false
+        var sawUnknown = false
+        var sawValid = false
+
+        for descriptor in descriptors {
+            switch await fetchAndCheckStatusList(descriptor: descriptor, issuerDid: issuerDid) {
+            case .revoked:
+                return .revoked
+            case .suspended:
+                sawSuspended = true
+            case .valid:
+                sawValid = true
+            case .expired, .unknown, .noStatusEndpoint:
+                sawUnknown = true
+            }
+        }
+
+        if sawSuspended { return .suspended }
+        if sawUnknown { return .unknown }
+        return sawValid ? .valid : .unknown
     }
 
     private func fetchAndCheckStatusList(descriptor: CredentialStatusDescriptor,
@@ -318,29 +354,28 @@ class StatusCheckService {
         return statusList.statusPurpose == statusPurposeSuspension ? .suspended : .revoked
     }
 
-    /// Parses the credential's own `credentialStatus` entry from the raw VC payload. The decoded
+    /// Parses the credential's own `credentialStatus` entries from the raw VC payload. The decoded
     /// `VerifiableCredentialDescriptor` only carries `id` / `type`, so the richer status-list fields
-    /// are read straight from the token payload here.
-    static func parseCredentialStatus(from raw: VerifiableCredential) -> CredentialStatusDescriptor? {
+    /// are read straight from the token payload here. Returns every entry (a `credentialStatus` may be
+    /// a single object or an array of objects) so the caller can evaluate revocation and suspension
+    /// independently.
+    static func parseCredentialStatuses(from raw: VerifiableCredential) -> [CredentialStatusDescriptor] {
         guard let compact = raw.rawValue ?? (try? raw.serialize()),
               let payload = jsonPayload(ofCompactJws: compact),
               let vc = payload["vc"] as? [String: Any] else {
-            return nil
+            return []
         }
 
-        let statusEntry: [String: Any]?
+        let entries: [[String: Any]]
         if let object = vc["credentialStatus"] as? [String: Any] {
-            statusEntry = object
+            entries = [object]
         } else if let array = vc["credentialStatus"] as? [[String: Any]] {
-            statusEntry = array.first
+            entries = array
         } else {
-            statusEntry = nil
+            entries = []
         }
 
-        guard let entry = statusEntry else {
-            return nil
-        }
-        return CredentialStatusDescriptor(json: entry)
+        return entries.compactMap { CredentialStatusDescriptor(json: $0) }
     }
 
     /// Reads `encodedList` and `statusPurpose` (defaulting to `"revocation"`) from a status list JWT

--- a/WalletLibrary/WalletLibrary/StatusCheck/StatusCheckService.swift
+++ b/WalletLibrary/WalletLibrary/StatusCheck/StatusCheckService.swift
@@ -1,0 +1,444 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import Foundation
+
+/**
+ * Determines the `VerifiedIdStatus` of a `VerifiedId`: first expiry (from the credential's own
+ * `expiresOn`, no network), then W3C StatusList2021 (fetch the issuer's list and check the bit).
+ *
+ * Status lists are resolved three ways, mirroring the Entra server: a direct HTTPS
+ * `statusListCredential`, a `did:web` reference (resolved to a service endpoint), or the legacy
+ * IdentityHub form (`urn:uuid:` id or `did:`-relative credential), which resolves the issuer's
+ * IdentityHub and POSTs a CollectionsQuery. Every fetched status list JWT is signature-verified and
+ * bound to the credential's issuer before its bits are trusted.
+ *
+ * The check is fail-open: every network, parsing, or verification failure resolves to `.unknown` so
+ * a check that can't complete never blocks the user. The server remains authoritative at presentation.
+ */
+class StatusCheckService {
+
+    private let configuration: LibraryConfiguration
+    private let validator: StatusListTokenValidator
+    private let dateProvider: () -> Date
+
+    init(configuration: LibraryConfiguration,
+         validator: StatusListTokenValidator? = nil,
+         dateProvider: @escaping () -> Date = { Date() }) {
+        self.configuration = configuration
+        self.validator = validator
+            ?? StatusListTokenValidator(didResolver: DIDDocumentNetworkCalls(urlSession: .shared))
+        self.dateProvider = dateProvider
+    }
+
+    func checkStatus(of verifiedId: VerifiedId) async -> VerifiedIdStatus {
+        if let expiresOn = verifiedId.expiresOn, expiresOn < dateProvider() {
+            return .expired
+        }
+
+        guard let credential = verifiedId as? VCVerifiedId else {
+            return .noStatusEndpoint
+        }
+
+        guard let descriptor = StatusCheckService.parseCredentialStatus(from: credential.raw) else {
+            return .noStatusEndpoint
+        }
+
+        let issuerDid = credential.raw.content.iss ?? ""
+        return await fetchAndCheckStatusList(descriptor: descriptor, issuerDid: issuerDid)
+    }
+
+    private func fetchAndCheckStatusList(descriptor: CredentialStatusDescriptor,
+                                         issuerDid: String) async -> VerifiedIdStatus {
+        let statusListCredential = descriptor.effectiveStatusListCredential
+
+        if let url = await resolveStatusListURL(statusListCredential) {
+            return await checkDirectStatusList(url: url, descriptor: descriptor, issuerDid: issuerDid)
+        }
+
+        if statusListCredential.hasPrefix("did:") || descriptor.id.hasPrefix("urn:uuid:") {
+            guard !issuerDid.isEmpty else { return .unknown }
+            return await checkStatusViaIdentityHub(descriptor: descriptor, issuerDid: issuerDid)
+        }
+
+        return .unknown
+    }
+
+    // MARK: - Direct (HTTPS / did:web) path
+
+    private func checkDirectStatusList(url: URL,
+                                       descriptor: CredentialStatusDescriptor,
+                                       issuerDid: String) async -> VerifiedIdStatus {
+        do {
+            let responseData = try await configuration.networking.fetch(url: url,
+                                                                        StatusListCredentialFetchOperation.self)
+            guard let jwt = StatusCheckService.compactJws(from: responseData),
+                  let statusList = await verifyAndExtractStatusList(fromJws: jwt, issuerDid: issuerDid) else {
+                return .unknown
+            }
+            return StatusCheckService.evaluate(statusList: statusList,
+                                               descriptor: descriptor,
+                                               bitIndex: descriptor.effectiveStatusListIndex)
+        } catch {
+            return .unknown
+        }
+    }
+
+    /// Resolves the status list credential to a fetchable HTTPS URL: a direct `https://` URL, or a
+    /// `did:web:` reference resolved through its DID document's service endpoint. Returns `nil` for
+    /// anything else (caller falls back to the IdentityHub path).
+    private func resolveStatusListURL(_ raw: String) async -> URL? {
+        if raw.hasPrefix("https://") {
+            return StatusCheckService.isWellFormedHttpsURL(raw) ? URL(string: raw) : nil
+        }
+        if raw.hasPrefix("did:web:") {
+            return await resolveDidWebURL(raw)
+        }
+        return nil
+    }
+
+    private func resolveDidWebURL(_ didURL: String) async -> URL? {
+        let did = didURL.components(separatedBy: "?").first ?? didURL
+        let serviceName = StatusCheckService.didURLQueryParameter(didURL, key: "service") ?? "IdentityHub"
+        let queries = StatusCheckService.didURLQueryParameter(didURL, key: "queries")
+
+        guard let services = await resolveDIDDocumentServices(did: did),
+              let service = StatusCheckService.findService(services, named: serviceName),
+              let endpoint = StatusCheckService.serviceEndpointURL(from: service) else {
+            return nil
+        }
+
+        guard let queries = queries else {
+            return URL(string: endpoint)
+        }
+        guard var components = URLComponents(string: endpoint) else { return nil }
+        var items = components.queryItems ?? []
+        items.append(URLQueryItem(name: "queries", value: queries))
+        components.queryItems = items
+        return components.url
+    }
+
+    // MARK: - IdentityHub (urn:uuid / did:-relative) path
+
+    private func checkStatusViaIdentityHub(descriptor: CredentialStatusDescriptor,
+                                           issuerDid: String) async -> VerifiedIdStatus {
+        guard let objectId = resolveIdentityHubObjectId(descriptor: descriptor) else {
+            return .unknown
+        }
+        let bitIndex = resolveStatusListBitIndex(descriptor: descriptor)
+
+        guard let services = await resolveDIDDocumentServices(did: issuerDid),
+              let hubService = StatusCheckService.findService(services, named: "IdentityHub"),
+              let hubEndpoint = StatusCheckService.serviceEndpointURL(from: hubService),
+              let hubURL = URL(string: hubEndpoint) else {
+            return .unknown
+        }
+
+        do {
+            let requestBody = StatusCheckService.buildCollectionsQueryBody(issuerDid: issuerDid, objectId: objectId)
+            let responseData = try await configuration.networking.post(requestBody: requestBody,
+                                                                       url: hubURL,
+                                                                       CollectionsQueryPostOperation.self)
+            guard let responseBody = String(data: responseData, encoding: .utf8) else {
+                return .unknown
+            }
+
+            var statusList = await verifyAndExtractStatusList(fromJws: responseBody, issuerDid: issuerDid)
+            if statusList == nil {
+                statusList = await extractStatusListFromCollectionsResponse(responseBody, issuerDid: issuerDid)
+            }
+
+            guard let resolved = statusList else {
+                return .unknown
+            }
+            return StatusCheckService.evaluate(statusList: resolved, descriptor: descriptor, bitIndex: bitIndex)
+        } catch {
+            return .unknown
+        }
+    }
+
+    /// IdentityHub object id (status list UUID) from a `urn:uuid:<id>?...` id or a
+    /// `did:...?queries=<base64url([{objectId}])>` credential.
+    private func resolveIdentityHubObjectId(descriptor: CredentialStatusDescriptor) -> String? {
+        if descriptor.id.hasPrefix("urn:uuid:") {
+            let body = String(descriptor.id.dropFirst("urn:uuid:".count))
+            return body.components(separatedBy: "?").first
+        }
+
+        let statusCredential = descriptor.effectiveStatusListCredential
+        if statusCredential.hasPrefix("did:") {
+            guard let encodedQueries = StatusCheckService.didURLQueryParameter(statusCredential, key: "queries"),
+                  let decoded = Data(base64URLEncoded: encodedQueries),
+                  let array = try? JSONSerialization.jsonObject(with: decoded) as? [[String: Any]],
+                  let objectId = array.first?["objectId"] as? String else {
+                return nil
+            }
+            return objectId
+        }
+        return nil
+    }
+
+    /// Bit index from the `urn:uuid:...?bit-index=N` id when present, else the descriptor's index.
+    private func resolveStatusListBitIndex(descriptor: CredentialStatusDescriptor) -> Int {
+        if descriptor.id.hasPrefix("urn:uuid:"),
+           let value = StatusCheckService.didURLQueryParameter(descriptor.id, key: "bit-index"),
+           let bitIndex = Int(value) {
+            return bitIndex
+        }
+        return descriptor.effectiveStatusListIndex
+    }
+
+    /// Extracts the status list from a CollectionsQuery envelope: each `replies[].entries[].data` is a
+    /// base64url-encoded JWT, decoded and verified via `verifyAndExtractStatusList` (raw value tried too).
+    private func extractStatusListFromCollectionsResponse(_ responseBody: String,
+                                                          issuerDid: String) async -> (encodedList: String, statusPurpose: String)? {
+        guard let data = responseBody.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let replies = root["replies"] as? [[String: Any]] else {
+            return nil
+        }
+
+        for reply in replies {
+            guard let entries = reply["entries"] as? [[String: Any]] else { continue }
+            for entry in entries {
+                guard let entryData = entry["data"] as? String else { continue }
+                if let decoded = StatusCheckService.base64DecodeToString(entryData),
+                   let result = await verifyAndExtractStatusList(fromJws: decoded, issuerDid: issuerDid) {
+                    return result
+                }
+                if let result = await verifyAndExtractStatusList(fromJws: entryData, issuerDid: issuerDid) {
+                    return result
+                }
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Verify + extract
+
+    /// Verifies a status list JWT (signature bound to `issuerDid`, plus `exp`) and returns its
+    /// `encodedList` / `statusPurpose`. Returns `nil` for an unsigned body or any failed check, so the
+    /// SDK never reads bits from unverified data.
+    private func verifyAndExtractStatusList(fromJws jws: String,
+                                            issuerDid: String) async -> (encodedList: String, statusPurpose: String)? {
+        guard let token = JwsToken<StatusListClaims>(from: jws) else {
+            return nil
+        }
+        do {
+            try await validator.validate(token, expectedIssuerDid: issuerDid, now: dateProvider())
+        } catch {
+            return nil
+        }
+        return StatusCheckService.extractStatusListInfo(fromJws: jws)
+    }
+
+    // MARK: - Pure helpers
+
+    /// Checks the status purpose matches (if declared), decompresses the list, and reads the bit.
+    static func evaluate(statusList: (encodedList: String, statusPurpose: String),
+                         descriptor: CredentialStatusDescriptor,
+                         bitIndex: Int) -> VerifiedIdStatus {
+        if !descriptor.statusPurpose.isEmpty, descriptor.statusPurpose != statusList.statusPurpose {
+            return .unknown
+        }
+        guard let decoded = Data(base64URLEncoded: statusList.encodedList),
+              let bitstring = decoded.gunzipped() else {
+            return .unknown
+        }
+        guard let isFlagged = checkBit(bitstring, index: bitIndex) else {
+            return .unknown
+        }
+        if !isFlagged {
+            return .valid
+        }
+        return statusList.statusPurpose == "suspension" ? .suspended : .revoked
+    }
+
+    /// Parses the credential's own `credentialStatus` entry from the raw VC payload. The decoded
+    /// `VerifiableCredentialDescriptor` only carries `id` / `type`, so the richer status-list fields
+    /// are read straight from the token payload here.
+    static func parseCredentialStatus(from raw: VerifiableCredential) -> CredentialStatusDescriptor? {
+        guard let compact = raw.rawValue ?? (try? raw.serialize()),
+              let payload = jsonPayload(ofCompactJws: compact),
+              let vc = payload["vc"] as? [String: Any] else {
+            return nil
+        }
+
+        let statusEntry: [String: Any]?
+        if let object = vc["credentialStatus"] as? [String: Any] {
+            statusEntry = object
+        } else if let array = vc["credentialStatus"] as? [[String: Any]] {
+            statusEntry = array.first
+        } else {
+            statusEntry = nil
+        }
+
+        guard let entry = statusEntry else {
+            return nil
+        }
+        return CredentialStatusDescriptor(json: entry)
+    }
+
+    /// Reads `encodedList` and `statusPurpose` (defaulting to `"revocation"`) from a status list JWT
+    /// payload, accepting both the top-level `credentialSubject` and the nested `vc.credentialSubject`.
+    static func extractStatusListInfo(fromJws jws: String) -> (encodedList: String, statusPurpose: String)? {
+        guard let payload = jsonPayload(ofCompactJws: jws) else {
+            return nil
+        }
+
+        let credentialSubject = (payload["credentialSubject"] as? [String: Any])
+            ?? ((payload["vc"] as? [String: Any])?["credentialSubject"] as? [String: Any])
+
+        guard let subject = credentialSubject,
+              let encodedList = subject["encodedList"] as? String else {
+            return nil
+        }
+
+        let statusPurpose = subject["statusPurpose"] as? String ?? "revocation"
+        return (encodedList, statusPurpose)
+    }
+
+    /// Reads the bit at [index] using least-significant-bit-first ordering (index 0 = LSB of byte 0),
+    /// i.e. `1 << (index % 8)`. This matches Entra's status list encoding; MSB-first ordering would
+    /// break revocation detection for any index that is not a multiple of 8.
+    ///
+    /// Returns `true` if the bit is set (revoked/suspended), `false` if clear (valid), or `nil` when
+    /// [index] is outside the bitstring (caller treats as `.unknown`).
+    static func checkBit(_ bitstring: Data, index: Int) -> Bool? {
+        guard index >= 0 else { return nil }
+        let byteIndex = index / 8
+        let bitOffset = index % 8
+        guard byteIndex < bitstring.count else { return nil }
+        let byte = bitstring[bitstring.startIndex + byteIndex]
+        return (Int(byte) & (1 << bitOffset)) != 0
+    }
+
+    static func isWellFormedHttpsURL(_ string: String) -> Bool {
+        guard let url = URL(string: string),
+              url.scheme?.lowercased() == "https",
+              let host = url.host, !host.isEmpty else {
+            return false
+        }
+        return true
+    }
+
+    /// Selects the named service from a DID document `service` array, by `type` or an `id` ending in
+    /// `#<name>`.
+    static func findService(_ services: [[String: Any]], named name: String) -> [String: Any]? {
+        return services.first { service in
+            let type = service["type"] as? String ?? ""
+            let id = service["id"] as? String ?? ""
+            return type == name || id.hasSuffix("#\(name)")
+        }
+    }
+
+    /// Reads a service endpoint URL from a DID document service entry, accepting a bare string, an
+    /// `{ instances: [...] }` (IdentityHub) or `{ origins: [...] }` (LinkedDomains) object, or an array.
+    static func serviceEndpointURL(from service: [String: Any]) -> String? {
+        let endpoint = service["serviceEndpoint"]
+        if let string = endpoint as? String {
+            return string
+        }
+        if let object = endpoint as? [String: Any] {
+            if let instances = object["instances"] as? [String], let first = instances.first {
+                return first
+            }
+            if let origins = object["origins"] as? [String], let first = origins.first {
+                return first
+            }
+            if let location = object["location"] as? String {
+                return location
+            }
+        }
+        if let strings = endpoint as? [String] {
+            return strings.first
+        }
+        return nil
+    }
+
+    static func buildCollectionsQueryBody(issuerDid: String, objectId: String) -> Data {
+        let body: [String: Any] = [
+            "requestId": UUID().uuidString,
+            "target": issuerDid,
+            "messages": [
+                ["descriptor": [
+                    "method": "CollectionsQuery",
+                    "objectId": objectId,
+                    "schema": "https://w3id.org/vc-status-list-2021/v1"
+                ]]
+            ]
+        ]
+        return (try? JSONSerialization.data(withJSONObject: body)) ?? Data()
+    }
+
+    /// Base64url-decodes an IdentityHub `data` field; returns `nil` unless it looks like a JWT (`eyJ`)
+    /// or JSON (`{`).
+    static func base64DecodeToString(_ encoded: String) -> String? {
+        guard let data = Data(base64URLEncoded: encoded),
+              let text = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (text.hasPrefix("eyJ") || trimmed.hasPrefix("{")) ? text : nil
+    }
+
+    /// Reads a query parameter from an opaque `did:` / `urn:` URL, whose `?...` lives in the
+    /// scheme-specific part rather than a standard URL query.
+    static func didURLQueryParameter(_ url: String, key: String) -> String? {
+        guard let questionMark = url.firstIndex(of: "?") else { return nil }
+        let afterQuestion = url[url.index(after: questionMark)...]
+        let query = afterQuestion.split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)
+            .first.map(String.init) ?? String(afterQuestion)
+
+        for pair in query.split(separator: "&") {
+            let components = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false).map(String.init)
+            let rawKey = components.first ?? ""
+            if (rawKey.removingPercentEncoding ?? rawKey) == key {
+                let rawValue = components.count > 1 ? components[1] : ""
+                return rawValue.removingPercentEncoding ?? rawValue
+            }
+        }
+        return nil
+    }
+
+    private func resolveDIDDocumentServices(did: String) async -> [[String: Any]]? {
+        guard let url = StatusCheckService.discoveryURL(for: did),
+              let data = try? await configuration.networking.fetch(url: url, StatusListCredentialFetchOperation.self),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        let didDocument = (json["didDocument"] as? [String: Any]) ?? json
+        return didDocument["service"] as? [[String: Any]]
+    }
+
+    private static func discoveryURL(for did: String) -> URL? {
+        guard var components = URLComponents(string: VCSDKConfiguration.sharedInstance.discoveryUrl) else {
+            return nil
+        }
+        let suffix = components.path.hasSuffix("/") ? did : "/" + did
+        components.path = components.path + suffix
+        return components.url
+    }
+
+    private static func compactJws(from data: Data) -> String? {
+        guard let body = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        let trimSet = CharacterSet(charactersIn: "\"").union(.whitespacesAndNewlines)
+        let trimmed = body.trimmingCharacters(in: trimSet)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func jsonPayload(ofCompactJws jws: String) -> [String: Any]? {
+        let segments = jws.components(separatedBy: ".")
+        guard segments.count >= 2,
+              let payloadData = Data(base64URLEncoded: segments[1]),
+              let json = try? JSONSerialization.jsonObject(with: payloadData),
+              let payload = json as? [String: Any] else {
+            return nil
+        }
+        return payload
+    }
+}

--- a/WalletLibrary/WalletLibrary/StatusCheck/StatusListCredentialFetchOperation.swift
+++ b/WalletLibrary/WalletLibrary/StatusCheck/StatusListCredentialFetchOperation.swift
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import Foundation
+
+/**
+ * Fetches a StatusList2021 credential (a signed JWT) directly from an issuer's HTTPS endpoint —
+ * the `statusListCredential` URL on a credential's `credentialStatus` entry. The body is returned
+ * verbatim as `Data` so the caller can parse it as a compact JWS.
+ */
+struct StatusListCredentialFetchOperation: WalletLibraryFetchOperation {
+
+    typealias ResponseBody = Data
+    typealias Decoder = StatusListResponseDecoder
+
+    var decoder = StatusListResponseDecoder()
+    var urlSession: URLSession
+    var urlRequest: URLRequest
+    var correlationVector: VerifiedIdCorrelationHeader?
+
+    init(url: URL,
+         additionalHeaders: [String: String]?,
+         urlSession: URLSession,
+         correlationVector: VerifiedIdCorrelationHeader?) {
+        self.urlSession = urlSession
+        self.urlRequest = URLRequest(url: url)
+        self.correlationVector = correlationVector
+        addHeadersToURLRequest(headers: additionalHeaders)
+    }
+}
+
+/// Returns the raw response bytes unchanged; the status list credential is a JWT, not JSON.
+struct StatusListResponseDecoder: Decoding {
+    func decode(data: Data) throws -> Data {
+        return data
+    }
+}

--- a/WalletLibrary/WalletLibrary/StatusCheck/StatusListTokenValidator.swift
+++ b/WalletLibrary/WalletLibrary/StatusCheck/StatusListTokenValidator.swift
@@ -11,6 +11,7 @@ import Foundation
 struct StatusListClaims: Claims {
     let iss: String?
     let exp: Int?
+    let nbf: Int?
 }
 
 enum StatusListValidationError: Error, Equatable {
@@ -20,13 +21,16 @@ enum StatusListValidationError: Error, Equatable {
     case issuerMismatch
     case noPublicKeysInIdentifierDocument
     case invalidSignature
+    case missingExpiry
     case expired
+    case notYetValid
 }
 
 /**
  * Verifies a fetched StatusList2021 credential JWT before its bits are trusted: the signature must
- * verify against the issuer's resolved DID document, the signer (token `kid` DID and payload `iss`)
- * must be the credential's own issuer, and any `exp` must be in the future (with clock skew).
+ * verify against the `kid`-referenced key in the issuer's resolved DID document, the signer (token
+ * `kid` DID and payload `iss`) must be the credential's own issuer, and a required `exp` must be in
+ * the future (with clock skew); any `nbf` must not be in the future.
  *
  * This is defense-in-depth — the issuance/presentation server remains authoritative — but it stops a
  * man-in-the-middle from forging a "valid" list. Modelled on `DomainLinkageCredentialValidator`.
@@ -77,11 +81,20 @@ class StatusListTokenValidator {
         }
         try verifySignature(of: token, keyId: keyId, document: document)
 
-        if let exp = token.content.exp {
-            let expiry = Date(timeIntervalSince1970: TimeInterval(exp) + clockSkewSeconds)
-            if expiry < now {
-                throw StatusListValidationError.expired
-            }
+        // `exp` is required: a status list with no expiry would be trusted indefinitely, letting a
+        // replayed older "all-clear" list mask a later revocation. A missing or past expiry throws, so
+        // the caller degrades to `.unknown` (fail-open) rather than trusting a stale list as "valid".
+        guard let exp = token.content.exp else {
+            throw StatusListValidationError.missingExpiry
+        }
+        if Date(timeIntervalSince1970: TimeInterval(exp) + clockSkewSeconds) < now {
+            throw StatusListValidationError.expired
+        }
+
+        // Reject a token that is not yet valid (`nbf` in the future, beyond clock skew).
+        if let nbf = token.content.nbf,
+           Date(timeIntervalSince1970: TimeInterval(nbf) - clockSkewSeconds) > now {
+            throw StatusListValidationError.notYetValid
         }
     }
 
@@ -92,14 +105,13 @@ class StatusListTokenValidator {
             throw StatusListValidationError.noPublicKeysInIdentifierDocument
         }
 
+        // Bind verification to the `kid`-referenced key only (matched by full id or `#fragment`), like
+        // `DomainLinkageCredentialValidator` — not "any key in the document" — for tighter key binding.
         let fragments = keyId.split(separator: "#")
         let keyFragment = fragments.count == 2 ? "#" + String(fragments[1]) : nil
 
         let matchingKeys = keys.filter { $0.id == keyId || (keyFragment != nil && $0.id == keyFragment) }
         for key in matchingKeys where verify(token, with: key) {
-            return
-        }
-        for key in keys where verify(token, with: key) {
             return
         }
 

--- a/WalletLibrary/WalletLibrary/StatusCheck/StatusListTokenValidator.swift
+++ b/WalletLibrary/WalletLibrary/StatusCheck/StatusListTokenValidator.swift
@@ -5,9 +5,9 @@
 
 import Foundation
 
-/// Minimal claims for a status list credential JWT. Only the fields needed to bind and time-box the
-/// token are modelled; `encodedList` / `statusPurpose` are read from the raw payload separately so a
-/// permissive shape can't block signature verification.
+/// Claims for a status list credential JWT. Only the fields needed to bind and time-box the token are
+/// modelled; `encodedList` / `statusPurpose` are read from the raw payload, so decoding never fails on
+/// list shape.
 struct StatusListClaims: Claims {
     let iss: String?
     let exp: Int?
@@ -47,7 +47,8 @@ class StatusListTokenValidator {
 
     func validate(_ token: JwsToken<StatusListClaims>,
                   expectedIssuerDid: String,
-                  now: Date) async throws {
+                  now: Date,
+                  preResolvedDocument: IdentifierDocument? = nil) async throws {
         guard !expectedIssuerDid.isEmpty else {
             throw StatusListValidationError.emptyIssuer
         }
@@ -67,7 +68,13 @@ class StatusListTokenValidator {
             throw StatusListValidationError.issuerMismatch
         }
 
-        let document = try await didResolver.getDocument(from: expectedIssuerDid)
+        // Reuse a document the caller already resolved for `expectedIssuerDid`; otherwise fetch it.
+        let document: IdentifierDocument
+        if let preResolvedDocument = preResolvedDocument {
+            document = preResolvedDocument
+        } else {
+            document = try await didResolver.getDocument(from: expectedIssuerDid)
+        }
         try verifySignature(of: token, keyId: keyId, document: document)
 
         if let exp = token.content.exp {

--- a/WalletLibrary/WalletLibrary/StatusCheck/StatusListTokenValidator.swift
+++ b/WalletLibrary/WalletLibrary/StatusCheck/StatusListTokenValidator.swift
@@ -1,0 +1,105 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import Foundation
+
+/// Minimal claims for a status list credential JWT. Only the fields needed to bind and time-box the
+/// token are modelled; `encodedList` / `statusPurpose` are read from the raw payload separately so a
+/// permissive shape can't block signature verification.
+struct StatusListClaims: Claims {
+    let iss: String?
+    let exp: Int?
+}
+
+enum StatusListValidationError: Error, Equatable {
+    case emptyIssuer
+    case missingKeyId
+    case malformedKeyId
+    case issuerMismatch
+    case noPublicKeysInIdentifierDocument
+    case invalidSignature
+    case expired
+}
+
+/**
+ * Verifies a fetched StatusList2021 credential JWT before its bits are trusted: the signature must
+ * verify against the issuer's resolved DID document, the signer (token `kid` DID and payload `iss`)
+ * must be the credential's own issuer, and any `exp` must be in the future (with clock skew).
+ *
+ * This is defense-in-depth — the issuance/presentation server remains authoritative — but it stops a
+ * man-in-the-middle from forging a "valid" list. Modelled on `DomainLinkageCredentialValidator`.
+ */
+class StatusListTokenValidator {
+
+    private let didResolver: DiscoveryNetworking
+    private let tokenVerifier: TokenVerifying
+    private let clockSkewSeconds: TimeInterval
+
+    init(didResolver: DiscoveryNetworking,
+         tokenVerifier: TokenVerifying = TokenVerifier(),
+         clockSkewSeconds: TimeInterval = 300) {
+        self.didResolver = didResolver
+        self.tokenVerifier = tokenVerifier
+        self.clockSkewSeconds = clockSkewSeconds
+    }
+
+    func validate(_ token: JwsToken<StatusListClaims>,
+                  expectedIssuerDid: String,
+                  now: Date) async throws {
+        guard !expectedIssuerDid.isEmpty else {
+            throw StatusListValidationError.emptyIssuer
+        }
+
+        guard let keyId = token.headers.keyId, !keyId.isEmpty else {
+            throw StatusListValidationError.missingKeyId
+        }
+
+        let signerDid = String(keyId.split(separator: "#").first ?? "")
+        guard !signerDid.isEmpty else {
+            throw StatusListValidationError.malformedKeyId
+        }
+        guard signerDid == expectedIssuerDid else {
+            throw StatusListValidationError.issuerMismatch
+        }
+        if let issuer = token.content.iss, !issuer.isEmpty, issuer != expectedIssuerDid {
+            throw StatusListValidationError.issuerMismatch
+        }
+
+        let document = try await didResolver.getDocument(from: expectedIssuerDid)
+        try verifySignature(of: token, keyId: keyId, document: document)
+
+        if let exp = token.content.exp {
+            let expiry = Date(timeIntervalSince1970: TimeInterval(exp) + clockSkewSeconds)
+            if expiry < now {
+                throw StatusListValidationError.expired
+            }
+        }
+    }
+
+    private func verifySignature(of token: JwsToken<StatusListClaims>,
+                                 keyId: String,
+                                 document: IdentifierDocument) throws {
+        guard let keys = document.verificationMethod, !keys.isEmpty else {
+            throw StatusListValidationError.noPublicKeysInIdentifierDocument
+        }
+
+        let fragments = keyId.split(separator: "#")
+        let keyFragment = fragments.count == 2 ? "#" + String(fragments[1]) : nil
+
+        let matchingKeys = keys.filter { $0.id == keyId || (keyFragment != nil && $0.id == keyFragment) }
+        for key in matchingKeys where verify(token, with: key) {
+            return
+        }
+        for key in keys where verify(token, with: key) {
+            return
+        }
+
+        throw StatusListValidationError.invalidSignature
+    }
+
+    private func verify(_ token: JwsToken<StatusListClaims>, with key: IdentifierDocumentPublicKey) -> Bool {
+        return (try? token.verify(using: tokenVerifier, withPublicKey: key.publicKeyJwk)) == true
+    }
+}

--- a/WalletLibrary/WalletLibrary/VerifiedId/VerifiedIdStatus.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedId/VerifiedIdStatus.swift
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+/**
+ * The status of a `VerifiedId`, returned by `VerifiedIdClient.checkVerifiedIdStatus(verifiedId:)`.
+ *
+ * Status is informational and best-effort: the issuance/presentation server remains the
+ * authoritative enforcement point. Callers should treat `.unknown` as "could not determine"
+ * (fail-open) rather than as a failure.
+ */
+public enum VerifiedIdStatus: Equatable {
+
+    /// Valid and not revoked, suspended, or expired.
+    case valid
+
+    /// The issuer has revoked this credential.
+    case revoked
+
+    /// The issuer has temporarily suspended this credential.
+    case suspended
+
+    /// The credential's `expiresOn` date has passed. Determined from the credential's own
+    /// `expiresOn`, without fetching the issuer's status list (unlike `.revoked`/`.suspended`).
+    case expired
+
+    /// Status could not be determined — e.g. a network error, an unrecognised response, or a
+    /// status-list reference using a method this SDK does not resolve.
+    case unknown
+
+    /// The credential carries no `credentialStatus`, so there is no status endpoint to check.
+    case noStatusEndpoint
+}

--- a/WalletLibrary/WalletLibrary/VerifiedId/VerifiedIdStatus.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedId/VerifiedIdStatus.swift
@@ -4,11 +4,10 @@
 *--------------------------------------------------------------------------------------------*/
 
 /**
- * The status of a `VerifiedId`, returned by `VerifiedIdClient.checkVerifiedIdStatus(verifiedId:)`.
+ * The status of a `VerifiedId`, returned by `VerifiedIdClient.checkVerifiedIdStatus(_:)`.
  *
- * Status is informational and best-effort: the issuance/presentation server remains the
- * authoritative enforcement point. Callers should treat `.unknown` as "could not determine"
- * (fail-open) rather than as a failure.
+ * Status is informational: the issuance/presentation server remains the authoritative enforcement
+ * point. Treat `.unknown` as "could not determine" (fail-open), not as a failure.
  */
 public enum VerifiedIdStatus: Equatable {
 

--- a/WalletLibrary/WalletLibrary/VerifiedIdClient.swift
+++ b/WalletLibrary/WalletLibrary/VerifiedIdClient.swift
@@ -36,6 +36,18 @@ public class VerifiedIdClient {
         }
     }
     
+    /// Checks whether a `VerifiedId` has been revoked, suspended, or expired.
+    ///
+    /// Expiry is determined locally from the credential's `expiresOn`; revocation and suspension are
+    /// resolved against the issuer's W3C StatusList2021 endpoint. The check is fail-open: any error
+    /// or indeterminate result returns `.unknown` and never throws. The presentation/issuance server
+    /// remains the authoritative enforcement point.
+    public func checkVerifiedIdStatus(_ verifiedId: VerifiedId) async -> VerifiedIdStatus {
+        configuration.networking.resetCorrelationHeader()
+        let service = StatusCheckService(configuration: configuration)
+        return await service.checkStatus(of: verifiedId)
+    }
+
     /// Encode a VerifiedId into Data.
     public func encode(verifiedId: VerifiedId) -> VerifiedIdResult<Data> {
         do {

--- a/WalletLibrary/WalletLibraryTests/Mocks/Requests/Manifest/MockIssuanceResponseContaining.swift
+++ b/WalletLibrary/WalletLibraryTests/Mocks/Requests/Manifest/MockIssuanceResponseContaining.swift
@@ -7,6 +7,8 @@
 
 struct MockIssuanceResponseContainer: IssuanceResponseContaining {
     
+    var audienceUrl: String = ""
+    
     private let mockAddRequirementCallback: ((Requirement) throws -> Void)?
     
     init(mockAddRequirementCallback: ((Requirement) throws -> Void)? = nil) {

--- a/WalletLibrary/WalletLibraryTests/Requests/OpenId/OpenIdPresentationRequestTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Requests/OpenId/OpenIdPresentationRequestTests.swift
@@ -233,7 +233,7 @@ class OpenIdPresentationRequestTests: XCTestCase
         // Arrange
         let mockRawOpenIdRequest = createMockRawOpenIdRequest()
         
-        let mockNetworkingLayer = MockLibraryNetworking.create(expectedResults: [("", PostPresentationResponseOperation.self)])
+        let mockNetworkingLayer = MockLibraryNetworking.create(expectedResults: [(MockSuccessfulCompletionResult(), PostPresentationResponseOperation.self)])
         let configuration = LibraryConfiguration(logger: WalletLibraryLogger(),
                                                  mapper: Mapper(),
                                                  networking: mockNetworkingLayer)
@@ -298,3 +298,7 @@ class OpenIdPresentationRequestTests: XCTestCase
         return mockPartialRequest
     }
 }
+
+/// A `Decodable` `SuccessfulCompletionResult` stand-in used to stub `PostPresentationResponseOperation`
+/// in `MockLibraryNetworking`, whose `ResponseBody` is the `SuccessfulCompletionResult` protocol.
+private struct MockSuccessfulCompletionResult: SuccessfulCompletionResult, Decodable {}

--- a/WalletLibrary/WalletLibraryTests/StatusCheck/StatusCheckServiceTests.swift
+++ b/WalletLibrary/WalletLibraryTests/StatusCheck/StatusCheckServiceTests.swift
@@ -1,0 +1,369 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import Foundation
+import Testing
+@testable import WalletLibrary
+
+/// Tests for the deterministic, network-free surface of `StatusCheckService`: bit reading, status
+/// list evaluation, GZIP inflation, and the DID/service-endpoint parsing helpers.
+struct StatusCheckServiceTests {
+
+    // A status list bitstring whose only set bit is index 5 (least-significant-bit-first within
+    // byte 0): 0b0010_0000. Byte 1 is empty, so indices 8...15 are all clear.
+    private static let bitstring = Data([0x20, 0x00])
+
+    // GZIP of `bitstring`, base64url-encoded — the form an `encodedList` arrives in.
+    private static let encodedList = "H4sIAAAAAAAC_1NgAABdNl3UAgAAAA"
+
+    // The same GZIP stream as raw bytes (canonical header, no FNAME).
+    private static let gzipBytes = Data([
+        0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff,
+        0x53, 0x60, 0x00, 0x00, 0x5d, 0x36, 0x5d, 0xd4, 0x02, 0x00, 0x00, 0x00
+    ])
+
+    // A GZIP stream of `bitstring` that sets the FNAME flag ("name.bin\0"), exercising the
+    // optional-field skipping in `gunzipped()`.
+    private static let gzipBytesWithName = Data([
+        0x1f, 0x8b, 0x08, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff,
+        0x6e, 0x61, 0x6d, 0x65, 0x2e, 0x62, 0x69, 0x6e, 0x00,
+        0x53, 0x60, 0x00, 0x00, 0x5d, 0x36, 0x5d, 0xd4, 0x02, 0x00, 0x00, 0x00
+    ])
+
+    // MARK: - checkBit
+
+    @Test func checkBit_readsLeastSignificantBitFirst() {
+        #expect(StatusCheckService.checkBit(Self.bitstring, index: 5) == true)
+        #expect(StatusCheckService.checkBit(Self.bitstring, index: 0) == false)
+        #expect(StatusCheckService.checkBit(Self.bitstring, index: 4) == false)
+        #expect(StatusCheckService.checkBit(Self.bitstring, index: 6) == false)
+        #expect(StatusCheckService.checkBit(Self.bitstring, index: 13) == false)
+    }
+
+    @Test func checkBit_indexOutsideBitstring_returnsNil() {
+        #expect(StatusCheckService.checkBit(Self.bitstring, index: 16) == nil)
+        #expect(StatusCheckService.checkBit(Self.bitstring, index: -1) == nil)
+    }
+
+    // MARK: - GZIP inflation
+
+    @Test func gunzip_basicStream_roundTrips() {
+        #expect(Self.gzipBytes.gunzipped() == Self.bitstring)
+    }
+
+    @Test func gunzip_streamWithFileNameFlag_roundTrips() {
+        #expect(Self.gzipBytesWithName.gunzipped() == Self.bitstring)
+    }
+
+    @Test func gunzip_nonGzipInput_returnsNil() {
+        #expect(Data([0x00, 0x01, 0x02, 0x03]).gunzipped() == nil)
+        #expect(Data().gunzipped() == nil)
+    }
+
+    // MARK: - evaluate
+
+    @Test func evaluate_bitClear_isValid() {
+        let descriptor = makeDescriptor(statusPurpose: "")
+        let result = StatusCheckService.evaluate(statusList: (Self.encodedList, "revocation"),
+                                                 descriptor: descriptor,
+                                                 bitIndex: 0)
+        #expect(result == .valid)
+    }
+
+    @Test func evaluate_bitSetForRevocation_isRevoked() {
+        let descriptor = makeDescriptor(statusPurpose: "revocation")
+        let result = StatusCheckService.evaluate(statusList: (Self.encodedList, "revocation"),
+                                                 descriptor: descriptor,
+                                                 bitIndex: 5)
+        #expect(result == .revoked)
+    }
+
+    @Test func evaluate_bitSetForSuspension_isSuspended() {
+        let descriptor = makeDescriptor(statusPurpose: "suspension")
+        let result = StatusCheckService.evaluate(statusList: (Self.encodedList, "suspension"),
+                                                 descriptor: descriptor,
+                                                 bitIndex: 5)
+        #expect(result == .suspended)
+    }
+
+    @Test func evaluate_purposeMismatch_isUnknown() {
+        let descriptor = makeDescriptor(statusPurpose: "revocation")
+        let result = StatusCheckService.evaluate(statusList: (Self.encodedList, "suspension"),
+                                                 descriptor: descriptor,
+                                                 bitIndex: 5)
+        #expect(result == .unknown)
+    }
+
+    @Test func evaluate_undecodableList_isUnknown() {
+        let descriptor = makeDescriptor(statusPurpose: "revocation")
+        let result = StatusCheckService.evaluate(statusList: ("not-a-valid-gzip", "revocation"),
+                                                 descriptor: descriptor,
+                                                 bitIndex: 5)
+        #expect(result == .unknown)
+    }
+
+    // MARK: - isWellFormedHttpsURL
+
+    @Test func isWellFormedHttpsURL_acceptsHttpsWithHost() {
+        #expect(StatusCheckService.isWellFormedHttpsURL("https://example.com/status/list") == true)
+    }
+
+    @Test func isWellFormedHttpsURL_rejectsNonHttpsOrHostless() {
+        #expect(StatusCheckService.isWellFormedHttpsURL("http://example.com") == false)
+        #expect(StatusCheckService.isWellFormedHttpsURL("https://") == false)
+        #expect(StatusCheckService.isWellFormedHttpsURL("ftp://example.com") == false)
+        #expect(StatusCheckService.isWellFormedHttpsURL("not a url") == false)
+    }
+
+    // MARK: - findService
+
+    @Test func findService_matchesByType() {
+        let services: [[String: Any]] = [["type": "IdentityHub", "serviceEndpoint": "https://hub"]]
+        #expect(StatusCheckService.findService(services, named: "IdentityHub") != nil)
+    }
+
+    @Test func findService_matchesByFragmentId() {
+        let services: [[String: Any]] = [["id": "did:web:issuer#IdentityHub", "serviceEndpoint": "https://hub"]]
+        #expect(StatusCheckService.findService(services, named: "IdentityHub") != nil)
+    }
+
+    @Test func findService_noMatch_returnsNil() {
+        let services: [[String: Any]] = [["type": "LinkedDomains", "serviceEndpoint": "https://ld"]]
+        #expect(StatusCheckService.findService(services, named: "IdentityHub") == nil)
+    }
+
+    // MARK: - serviceEndpointURL
+
+    @Test func serviceEndpointURL_bareString() {
+        #expect(StatusCheckService.serviceEndpointURL(from: ["serviceEndpoint": "https://hub"]) == "https://hub")
+    }
+
+    @Test func serviceEndpointURL_identityHubInstances() {
+        let service: [String: Any] = ["serviceEndpoint": ["instances": ["https://hub1", "https://hub2"]]]
+        #expect(StatusCheckService.serviceEndpointURL(from: service) == "https://hub1")
+    }
+
+    @Test func serviceEndpointURL_linkedDomainsOrigins() {
+        let service: [String: Any] = ["serviceEndpoint": ["origins": ["https://origin1"]]]
+        #expect(StatusCheckService.serviceEndpointURL(from: service) == "https://origin1")
+    }
+
+    @Test func serviceEndpointURL_locationObject() {
+        let service: [String: Any] = ["serviceEndpoint": ["location": "https://loc"]]
+        #expect(StatusCheckService.serviceEndpointURL(from: service) == "https://loc")
+    }
+
+    @Test func serviceEndpointURL_array() {
+        let service: [String: Any] = ["serviceEndpoint": ["https://first", "https://second"]]
+        #expect(StatusCheckService.serviceEndpointURL(from: service) == "https://first")
+    }
+
+    @Test func serviceEndpointURL_missing_returnsNil() {
+        #expect(StatusCheckService.serviceEndpointURL(from: ["type": "IdentityHub"]) == nil)
+    }
+
+    // MARK: - didURLQueryParameter
+
+    @Test func didURLQueryParameter_extractsNamedValue() {
+        let url = "did:web:example.com?service=IdentityHub&queries=YWJj"
+        #expect(StatusCheckService.didURLQueryParameter(url, key: "queries") == "YWJj")
+        #expect(StatusCheckService.didURLQueryParameter(url, key: "service") == "IdentityHub")
+    }
+
+    @Test func didURLQueryParameter_stopsAtFragment() {
+        let url = "did:ion:abc?queries=eyJ0ZXN0Ijox#fragment"
+        #expect(StatusCheckService.didURLQueryParameter(url, key: "queries") == "eyJ0ZXN0Ijox")
+    }
+
+    @Test func didURLQueryParameter_missing_returnsNil() {
+        #expect(StatusCheckService.didURLQueryParameter("did:web:example.com", key: "queries") == nil)
+    }
+
+    // MARK: - buildCollectionsQueryBody
+
+    @Test func buildCollectionsQueryBody_buildsValidCollectionsQuery() throws {
+        let body = StatusCheckService.buildCollectionsQueryBody(issuerDid: "did:web:issuer", objectId: "object-123")
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        #expect(json["target"] as? String == "did:web:issuer")
+        let messages = try #require(json["messages"] as? [[String: Any]])
+        let descriptor = try #require(messages.first?["descriptor"] as? [String: Any])
+        #expect(descriptor["method"] as? String == "CollectionsQuery")
+        #expect(descriptor["objectId"] as? String == "object-123")
+        #expect(descriptor["schema"] as? String == "https://w3id.org/vc-status-list-2021/v1")
+    }
+
+    // MARK: - Helpers
+
+    private func makeDescriptor(statusPurpose: String) -> CredentialStatusDescriptor {
+        let descriptor = CredentialStatusDescriptor(json: ["id": "urn:uuid:test", "statusPurpose": statusPurpose])
+        return descriptor!
+    }
+}
+
+/// Tests for `CredentialStatusDescriptor`'s normalisation across the StatusList2021 /
+/// RevocationList2021 / RevocationList2020 credential-status type variants.
+struct CredentialStatusDescriptorTests {
+
+    @Test func statusList2021Entry_normalisesCredentialAndIndex() {
+        let descriptor = CredentialStatusDescriptor(json: [
+            "id": "urn:uuid:abc",
+            "type": "StatusList2021Entry",
+            "statusPurpose": "revocation",
+            "statusListIndex": 5,
+            "statusListCredential": "https://issuer/status/list"
+        ])
+        #expect(descriptor?.effectiveStatusListCredential == "https://issuer/status/list")
+        #expect(descriptor?.effectiveStatusListIndex == 5)
+    }
+
+    @Test func revocationList2020_normalisesViaRevocationFields() {
+        let descriptor = CredentialStatusDescriptor(json: [
+            "id": "urn:uuid:def",
+            "type": "RevocationList2020Status",
+            "revocationListIndex": 7,
+            "revocationListCredential": "https://issuer/revocation/list"
+        ])
+        #expect(descriptor?.effectiveStatusListCredential == "https://issuer/revocation/list")
+        #expect(descriptor?.effectiveStatusListIndex == 7)
+    }
+
+    @Test func numericStringIndex_isParsed() {
+        let descriptor = CredentialStatusDescriptor(json: [
+            "id": "urn:uuid:ghi",
+            "statusListIndex": "9",
+            "statusListCredential": "https://issuer/status/list"
+        ])
+        #expect(descriptor?.effectiveStatusListIndex == 9)
+    }
+
+    @Test func emptyStringCredential_isTreatedAsAbsent() {
+        let descriptor = CredentialStatusDescriptor(json: [
+            "id": "urn:uuid:jkl",
+            "statusListCredential": "",
+            "revocationListIndex": 3,
+            "revocationListCredential": "https://issuer/revocation/list"
+        ])
+        #expect(descriptor?.statusListCredential == nil)
+        #expect(descriptor?.effectiveStatusListCredential == "https://issuer/revocation/list")
+        #expect(descriptor?.effectiveStatusListIndex == 3)
+    }
+
+    @Test func noCredentialAndNoId_returnsNil() {
+        let descriptor = CredentialStatusDescriptor(json: ["statusPurpose": "revocation"])
+        #expect(descriptor == nil)
+    }
+
+    @Test func idWithoutCredential_isRetainedForIdentityHubLookup() {
+        let descriptor = CredentialStatusDescriptor(json: ["id": "urn:uuid:mno"])
+        #expect(descriptor != nil)
+        #expect(descriptor?.effectiveStatusListCredential == nil)
+    }
+}
+
+/// Tests for `StatusListTokenValidator`: issuer binding, signature verification, expiry, and reuse of
+/// a pre-resolved DID document (so the IdentityHub path does not fetch it twice).
+struct StatusListTokenValidatorTests {
+
+    private let issuer = "did:web:issuer.example"
+
+    @Test func emptyExpectedIssuer_throwsEmptyIssuer() async {
+        let validator = makeValidator(verifies: true)
+        let token = makeToken(keyId: "\(issuer)#key-1", issuer: issuer, expiry: nil)
+        await #expect(throws: StatusListValidationError.emptyIssuer) {
+            try await validator.validate(token, expectedIssuerDid: "", now: Date())
+        }
+    }
+
+    @Test func missingKeyId_throwsMissingKeyId() async {
+        let validator = makeValidator(verifies: true)
+        let token = makeToken(keyId: nil, issuer: issuer, expiry: nil)
+        await #expect(throws: StatusListValidationError.missingKeyId) {
+            try await validator.validate(token, expectedIssuerDid: issuer, now: Date())
+        }
+    }
+
+    @Test func signerDidNotIssuer_throwsIssuerMismatch() async {
+        let validator = makeValidator(verifies: true)
+        let token = makeToken(keyId: "did:web:attacker#key-1", issuer: "did:web:attacker", expiry: nil)
+        await #expect(throws: StatusListValidationError.issuerMismatch) {
+            try await validator.validate(token, expectedIssuerDid: issuer, now: Date())
+        }
+    }
+
+    @Test func validSignatureWithPreResolvedDocument_succeedsWithoutResolving() async throws {
+        // The resolver throws if hit; a passing validation proves the pre-resolved document was reused.
+        let validator = makeValidator(verifies: true)
+        let token = makeToken(keyId: "\(issuer)#key-1", issuer: issuer, expiry: nil)
+        try await validator.validate(token,
+                                     expectedIssuerDid: issuer,
+                                     now: Date(),
+                                     preResolvedDocument: makeDocument(keyId: "#key-1"))
+    }
+
+    @Test func invalidSignature_throwsInvalidSignature() async {
+        let validator = makeValidator(verifies: false)
+        let token = makeToken(keyId: "\(issuer)#key-1", issuer: issuer, expiry: nil)
+        await #expect(throws: StatusListValidationError.invalidSignature) {
+            try await validator.validate(token,
+                                         expectedIssuerDid: issuer,
+                                         now: Date(),
+                                         preResolvedDocument: makeDocument(keyId: "#key-1"))
+        }
+    }
+
+    @Test func expiredToken_throwsExpired() async {
+        let validator = makeValidator(verifies: true)
+        let pastExpiry = Int(Date().timeIntervalSince1970) - 10_000
+        let token = makeToken(keyId: "\(issuer)#key-1", issuer: issuer, expiry: pastExpiry)
+        await #expect(throws: StatusListValidationError.expired) {
+            try await validator.validate(token,
+                                         expectedIssuerDid: issuer,
+                                         now: Date(),
+                                         preResolvedDocument: makeDocument(keyId: "#key-1"))
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeValidator(verifies: Bool) -> StatusListTokenValidator {
+        StatusListTokenValidator(didResolver: ThrowingDiscoveryNetworking(),
+                                 tokenVerifier: StubTokenVerifier(result: verifies))
+    }
+
+    private func makeToken(keyId: String?, issuer: String?, expiry: Int?) -> JwsToken<StatusListClaims> {
+        let header = Header(keyId: keyId)
+        let claims = StatusListClaims(iss: issuer, exp: expiry)
+        return JwsToken(headers: header, content: claims)!
+    }
+
+    private func makeDocument(keyId: String) -> IdentifierDocument {
+        let jwk = PublicJWK(x: "AAAA", y: "AAAA", keyType: "EC", keyId: keyId, algorithm: "ES256K", curve: "secp256k1")
+        let key = IdentifierDocumentPublicKey(id: keyId,
+                                              type: "EcdsaSecp256k1VerificationKey2019",
+                                              controller: nil,
+                                              publicKeyJwk: jwk,
+                                              purposes: nil)
+        return IdentifierDocument(service: nil, verificationMethod: [key], authentication: [], id: issuer)
+    }
+}
+
+// MARK: - Test doubles
+
+/// A `DiscoveryNetworking` that always throws, used to prove the validator does not fetch a DID
+/// document when a pre-resolved one is supplied.
+private struct ThrowingDiscoveryNetworking: DiscoveryNetworking {
+    func getDocument(from identifier: String) async throws -> IdentifierDocument {
+        throw StatusListValidationError.noPublicKeysInIdentifierDocument
+    }
+}
+
+/// A `TokenVerifying` whose signature-verification result is fixed by the test.
+private struct StubTokenVerifier: TokenVerifying {
+    let result: Bool
+    func verify<T>(token: JwsToken<T>, usingPublicKey key: JWK) throws -> Bool {
+        return result
+    }
+}

--- a/WalletLibrary/WalletLibraryTests/StatusCheck/StatusCheckServiceTests.swift
+++ b/WalletLibrary/WalletLibraryTests/StatusCheck/StatusCheckServiceTests.swift
@@ -293,14 +293,53 @@ struct StatusListTokenValidatorTests {
         }
     }
 
-    @Test func validSignatureWithPreResolvedDocument_succeedsWithoutResolving() async throws {
+    @Test func validSignatureWithFutureExpiry_succeedsWithoutResolving() async throws {
         // The resolver throws if hit; a passing validation proves the pre-resolved document was reused.
         let validator = makeValidator(verifies: true)
-        let token = makeToken(keyId: "\(issuer)#key-1", issuer: issuer, expiry: nil)
+        let futureExpiry = Int(Date().timeIntervalSince1970) + 10_000
+        let token = makeToken(keyId: "\(issuer)#key-1", issuer: issuer, expiry: futureExpiry)
         try await validator.validate(token,
                                      expectedIssuerDid: issuer,
                                      now: Date(),
                                      preResolvedDocument: makeDocument(keyId: "#key-1"))
+    }
+
+    @Test func missingExpiry_throwsMissingExpiry() async {
+        let validator = makeValidator(verifies: true)
+        let token = makeToken(keyId: "\(issuer)#key-1", issuer: issuer, expiry: nil)
+        await #expect(throws: StatusListValidationError.missingExpiry) {
+            try await validator.validate(token,
+                                         expectedIssuerDid: issuer,
+                                         now: Date(),
+                                         preResolvedDocument: makeDocument(keyId: "#key-1"))
+        }
+    }
+
+    @Test func notYetValidToken_throwsNotYetValid() async {
+        let validator = makeValidator(verifies: true)
+        let futureExpiry = Int(Date().timeIntervalSince1970) + 10_000
+        let futureNotBefore = Int(Date().timeIntervalSince1970) + 5_000
+        let token = makeToken(keyId: "\(issuer)#key-1", issuer: issuer, expiry: futureExpiry, notBefore: futureNotBefore)
+        await #expect(throws: StatusListValidationError.notYetValid) {
+            try await validator.validate(token,
+                                         expectedIssuerDid: issuer,
+                                         now: Date(),
+                                         preResolvedDocument: makeDocument(keyId: "#key-1"))
+        }
+    }
+
+    @Test func signatureVerifiesOnlyKidReferencedKey_notAnyKey() async {
+        // The kid-referenced key (#key-1) is absent from the document — only an unrelated #key-2 is
+        // present. Tight binding means we do NOT fall back to trying #key-2, so this fails.
+        let validator = makeValidator(verifies: true)
+        let futureExpiry = Int(Date().timeIntervalSince1970) + 10_000
+        let token = makeToken(keyId: "\(issuer)#key-1", issuer: issuer, expiry: futureExpiry)
+        await #expect(throws: StatusListValidationError.invalidSignature) {
+            try await validator.validate(token,
+                                         expectedIssuerDid: issuer,
+                                         now: Date(),
+                                         preResolvedDocument: makeDocument(keyId: "#key-2"))
+        }
     }
 
     @Test func invalidSignature_throwsInvalidSignature() async {
@@ -333,9 +372,9 @@ struct StatusListTokenValidatorTests {
                                  tokenVerifier: StubTokenVerifier(result: verifies))
     }
 
-    private func makeToken(keyId: String?, issuer: String?, expiry: Int?) -> JwsToken<StatusListClaims> {
+    private func makeToken(keyId: String?, issuer: String?, expiry: Int?, notBefore: Int? = nil) -> JwsToken<StatusListClaims> {
         let header = Header(keyId: keyId)
-        let claims = StatusListClaims(iss: issuer, exp: expiry)
+        let claims = StatusListClaims(iss: issuer, exp: expiry, nbf: notBefore)
         return JwsToken(headers: header, content: claims)!
     }
 
@@ -365,5 +404,204 @@ private struct StubTokenVerifier: TokenVerifying {
     let result: Bool
     func verify<T>(token: JwsToken<T>, usingPublicKey key: JWK) throws -> Bool {
         return result
+    }
+}
+
+/// End-to-end tests for `StatusCheckService.checkStatus(of:)`: expiry short-circuit, the
+/// no-status-endpoint path, that OpenID4VCI credentials are inspected (not silently skipped), and
+/// that every `credentialStatus` entry is evaluated so a suspension behind a clear revocation is caught.
+struct StatusCheckServiceOrchestrationTests {
+
+    private let helper = MockVerifiableCredentialHelper()
+    private let issuer = "did:web:issuer.example"
+
+    // GZIP+base64url of a bitstring with bit 5 set (flagged: revoked/suspended).
+    private static let bitSetEncodedList = "H4sIAAAAAAAC_1NgAABdNl3UAgAAAA"
+    // GZIP+base64url of an all-clear bitstring (valid).
+    private static let bitClearEncodedList = "H4sIAAAAAAAC_2NgAAD_EtlBAgAAAA"
+
+    private var futureUnixTime: Int { Int(Date().timeIntervalSince1970) + 100_000 }
+    private var pastUnixTime: Int { Int(Date().timeIntervalSince1970) - 100_000 }
+
+    @Test func expiredCredential_returnsExpired() async {
+        let service = makeService(networking: ThrowingNetworking())
+        let credential = makeVCVerifiedId(credentialStatus: nil, expiry: pastUnixTime)
+        let status = await service.checkStatus(of: credential)
+        #expect(status == .expired)
+    }
+
+    @Test func noCredentialStatus_returnsNoStatusEndpoint() async {
+        let service = makeService(networking: ThrowingNetworking())
+        let credential = makeVCVerifiedId(credentialStatus: nil, expiry: futureUnixTime)
+        let status = await service.checkStatus(of: credential)
+        #expect(status == .noStatusEndpoint)
+    }
+
+    @Test func openID4VCICredentialWithStatus_isInspectedNotSkipped() async throws {
+        // Regression guard: the cast is to `InternalVerifiedId`, so an OpenID4VCI credential carrying a
+        // status endpoint is inspected. The fetch throws, so the result is the indeterminate `.unknown`
+        // — never `.noStatusEndpoint`, which a caller could read as "nothing to check, accept it".
+        let service = makeService(networking: ThrowingNetworking())
+        let credential = try makeOpenID4VCIVerifiedId(statusListCredential: "https://issuer.example/status/1",
+                                                      expiry: futureUnixTime)
+        let status = await service.checkStatus(of: credential)
+        #expect(status == .unknown)
+    }
+
+    @Test func directHttpsRevocationBitSet_returnsRevoked() async {
+        let listURL = "https://issuer.example/revocation/1"
+        let networking = MapNetworking(bodies: [listURL: statusListJws(encodedList: Self.bitSetEncodedList,
+                                                                       statusPurpose: "revocation")])
+        let service = makeService(networking: networking, validator: AcceptingValidator())
+        let credential = makeVCVerifiedId(credentialStatus: [statusEntry(listURL: listURL, index: 5, purpose: "revocation")],
+                                          expiry: futureUnixTime)
+        let status = await service.checkStatus(of: credential)
+        #expect(status == .revoked)
+    }
+
+    @Test func multipleEntries_suspensionBehindClearRevocation_returnsSuspended() async {
+        // Revocation bit clear, suspension bit set. Evaluating only the first entry would report
+        // `.valid`; checking every entry surfaces the suspension.
+        let revocationURL = "https://issuer.example/revocation/1"
+        let suspensionURL = "https://issuer.example/suspension/1"
+        let networking = MapNetworking(bodies: [
+            revocationURL: statusListJws(encodedList: Self.bitClearEncodedList, statusPurpose: "revocation"),
+            suspensionURL: statusListJws(encodedList: Self.bitSetEncodedList, statusPurpose: "suspension")
+        ])
+        let service = makeService(networking: networking, validator: AcceptingValidator())
+        let credential = makeVCVerifiedId(credentialStatus: [
+            statusEntry(listURL: revocationURL, index: 5, purpose: "revocation"),
+            statusEntry(listURL: suspensionURL, index: 5, purpose: "suspension")
+        ], expiry: futureUnixTime)
+        let status = await service.checkStatus(of: credential)
+        #expect(status == .suspended)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeService(networking: LibraryNetworking,
+                             validator: StatusListTokenValidator? = nil) -> StatusCheckService {
+        StatusCheckService(configuration: LibraryConfiguration(networking: networking),
+                           validator: validator)
+    }
+
+    private func statusEntry(listURL: String, index: Int, purpose: String) -> [String: Any] {
+        ["id": "urn:uuid:\(purpose)",
+         "type": "StatusList2021Entry",
+         "statusListCredential": listURL,
+         "statusListIndex": index,
+         "statusPurpose": purpose]
+    }
+
+    /// Builds a `VCVerifiedId` whose `raw.rawValue` carries the given `credentialStatus` (single object
+    /// when one entry, array when several). Using the raw-value initializer sidesteps typed decoding,
+    /// which models `credentialStatus` as a single object and so can't represent the array form.
+    private func makeVCVerifiedId(credentialStatus: [[String: Any]]?, expiry: Int) -> VCVerifiedId {
+        var vc: [String: Any] = [
+            "@context": ["https://www.w3.org/2018/credentials/v1"],
+            "type": ["VerifiableCredential"],
+            "credentialSubject": ["name": "test"]
+        ]
+        if let credentialStatus {
+            vc["credentialStatus"] = credentialStatus.count == 1 ? credentialStatus[0] : credentialStatus
+        }
+        let payload: [String: Any] = ["jti": "urn:vc:test", "iss": issuer, "iat": 0, "exp": expiry, "vc": vc]
+        let content = VCClaims(jti: "urn:vc:test", iss: issuer, sub: "", iat: 0, exp: expiry, vc: nil)
+        let raw = VerifiableCredential(headers: Header(), content: content, rawValue: Self.compactJws(payload))!
+        return try! VCVerifiedId(raw: raw, from: helper.createMockContract())
+    }
+
+    private func makeOpenID4VCIVerifiedId(statusListCredential: String, expiry: Int) throws -> OpenID4VCIVerifiedId {
+        let vc: [String: Any] = [
+            "@context": ["https://www.w3.org/2018/credentials/v1"],
+            "type": ["VerifiableCredential"],
+            "credentialSubject": ["name": "test"],
+            "credentialStatus": ["id": "urn:uuid:status",
+                                 "type": "StatusList2021Entry",
+                                 "statusListCredential": statusListCredential,
+                                 "statusListIndex": "3",
+                                 "statusPurpose": "revocation"]
+        ]
+        let payload: [String: Any] = ["jti": "urn:vc:openid", "iss": issuer, "iat": 0, "exp": expiry, "vc": vc]
+        let config = CredentialConfiguration(format: nil,
+                                             scope: nil,
+                                             cryptographic_binding_methods_supported: nil,
+                                             cryptographic_suites_supported: nil,
+                                             credential_definition: nil,
+                                             display: nil,
+                                             proof_types_supported: nil)
+        return try OpenID4VCIVerifiedId(raw: Self.compactJws(payload),
+                                        issuerName: "Test Issuer",
+                                        configuration: config)
+    }
+
+    private func statusListJws(encodedList: String, statusPurpose: String) -> Data {
+        let payload: [String: Any] = [
+            "iss": issuer,
+            "vc": ["credentialSubject": ["encodedList": encodedList, "statusPurpose": statusPurpose]]
+        ]
+        return Data(Self.compactJws(payload).utf8)
+    }
+
+    private static func compactJws(_ payload: [String: Any]) -> String {
+        let header = base64URL(try! JSONSerialization.data(withJSONObject: ["alg": "ES256K", "typ": "JWT"]))
+        let body = base64URL(try! JSONSerialization.data(withJSONObject: payload))
+        return "\(header).\(body).AAAA"
+    }
+
+    private static func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+/// A `LibraryNetworking` returning canned response bodies keyed by URL; unmapped requests throw.
+private struct MapNetworking: LibraryNetworking {
+    let bodies: [String: Data]
+    func resetCorrelationHeader() {}
+    func fetch<Operation: WalletLibraryFetchOperation>(url: URL,
+                                                       _ type: Operation.Type,
+                                                       additionalHeaders: [String: String]?) async throws -> Operation.ResponseBody {
+        guard let data = bodies[url.absoluteString], let body = data as? Operation.ResponseBody else {
+            throw StatusListValidationError.noPublicKeysInIdentifierDocument
+        }
+        return body
+    }
+    func post<Operation: WalletLibraryPostOperation>(requestBody: Operation.RequestBody,
+                                                     url: URL,
+                                                     _ type: Operation.Type,
+                                                     additionalHeaders: [String: String]?) async throws -> Operation.ResponseBody {
+        throw StatusListValidationError.noPublicKeysInIdentifierDocument
+    }
+}
+
+/// A `LibraryNetworking` that throws on every request, proving a credential is still inspected even
+/// when its status list can't be fetched.
+private struct ThrowingNetworking: LibraryNetworking {
+    func resetCorrelationHeader() {}
+    func fetch<Operation: WalletLibraryFetchOperation>(url: URL,
+                                                       _ type: Operation.Type,
+                                                       additionalHeaders: [String: String]?) async throws -> Operation.ResponseBody {
+        throw StatusListValidationError.noPublicKeysInIdentifierDocument
+    }
+    func post<Operation: WalletLibraryPostOperation>(requestBody: Operation.RequestBody,
+                                                     url: URL,
+                                                     _ type: Operation.Type,
+                                                     additionalHeaders: [String: String]?) async throws -> Operation.ResponseBody {
+        throw StatusListValidationError.noPublicKeysInIdentifierDocument
+    }
+}
+
+/// A validator that accepts every token, isolating the orchestration tests from signature and
+/// freshness checks (covered by `StatusListTokenValidatorTests`).
+private final class AcceptingValidator: StatusListTokenValidator {
+    init() { super.init(didResolver: ThrowingDiscoveryNetworking()) }
+    override func validate(_ token: JwsToken<StatusListClaims>,
+                           expectedIssuerDid: String,
+                           now: Date,
+                           preResolvedDocument: IdentifierDocument?) async throws {
+        // Accept: bits are trusted for these orchestration tests.
     }
 }


### PR DESCRIPTION
Adds a status-check API so an app can detect a revoked, suspended, or expired `VerifiedId` ahead of a presentation, instead of only at presentation time.

```swift
VerifiedIdClient.checkVerifiedIdStatus(_:) async -> VerifiedIdStatus
// .valid / .revoked / .suspended / .expired / .unknown / .noStatusEndpoint
```

The check is fail-open: any network, parsing, or verification failure resolves to `.unknown`, so a check that cannot complete never blocks the user. The issuance/presentation server remains the authoritative enforcement point.

## Implementation (`WalletLibrary/StatusCheck/`)

- **StatusCheckService** — checks local expiry first, then resolves the W3C StatusList2021 list three ways: direct HTTPS, `did:web` (via its service endpoint), and the legacy IdentityHub (`urn:uuid:` / `did:`-relative) form. It base64url-decodes and gzip-inflates `encodedList` and reads the status bit least-significant-bit-first to match Entra's encoding.
- **StatusListTokenValidator** — verifies the list JWT signature against the issuer's resolved DID document, binds the signer (`kid` DID and `iss`) to the credential's issuer, and enforces `exp` with clock skew. Bits are read only after the token is verified.
- **CredentialStatusDescriptor** — normalises the `StatusList2021Entry` / `RevocationList2021Status` / `RevocationList2020Status` variants behind `effectiveStatusListCredential` / `effectiveStatusListIndex`.
- **Networking** — `StatusListCredentialFetchOperation` (GET the list) and `CollectionsQueryPostOperation` (POST an IdentityHub CollectionsQuery). The IdentityHub path resolves the issuer DID document once and reuses it for both endpoint lookup and signature verification.
- **Data+Gzip** — inflates the gzip `encodedList` via the Compression framework.

DID resolution uses the SDK's discovery resolver, which handles `did:web` and ION.

## Validation

- New Swift Testing suite covering bit reading, status evaluation, gzip inflation, descriptor normalisation, DID/endpoint parsing, and token validation.
- Full `WalletLibraryTests` suite passes (634 tests, 0 failures) on iOS Simulator.

## Type of change

- [x] Feature work

## Risk

- [x] Medium — new feature isolated to a new `StatusCheck/` module plus one additive public API. Existing flows are unchanged.
