### PR TITLE
rohitluthra/openid4vci-issuer-binding-fix

### DIFF
--- a/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
+++ b/WalletLibrary/WalletLibrary.xcodeproj/project.pbxproj
@@ -583,6 +583,7 @@
 		A4DC99822B7D29FF008F389F /* PresentationExchangeVerifiedIdRequirementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4DC99812B7D29FF008F389F /* PresentationExchangeVerifiedIdRequirementTests.swift */; };
 		A4DF2BF02E9EF8A4000AE314 /* MatchSubjectCryptoRequirement.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4DF2BEE2E9EF89B000AE314 /* MatchSubjectCryptoRequirement.swift */; };
 		A4F39A8B2B91571E005C12FC /* ExtensionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4F39A8A2B91571E005C12FC /* ExtensionConfiguration.swift */; };
+		C2664A8238035CC7F3F12290 /* OpenID4VCIPreAuthTokenResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579AB305E7D8B83237CB22B1 /* OpenID4VCIPreAuthTokenResolverTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1179,6 +1180,7 @@
 		55F01CD32ACE100B000794B4 /* ES256PublicKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ES256PublicKeyTests.swift; sourceTree = "<group>"; };
 		55FE70792B72E7C600CC3018 /* OpenId4VCIProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenId4VCIProcessor.swift; sourceTree = "<group>"; };
 		55FE70812B730D1500CC3018 /* CredentialMetadataFetchOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialMetadataFetchOperation.swift; sourceTree = "<group>"; };
+		579AB305E7D8B83237CB22B1 /* OpenID4VCIPreAuthTokenResolverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OpenID4VCIPreAuthTokenResolverTests.swift; sourceTree = "<group>"; };
 		A48C1EB52B8FF19000545FF6 /* VerifiedIdSerializing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedIdSerializing.swift; sourceTree = "<group>"; };
 		A497435A2B8EA367004851C2 /* VerifiedIdPartialRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedIdPartialRequest.swift; sourceTree = "<group>"; };
 		A497435E2B8EB29B004851C2 /* PresentationExchangeRequirement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationExchangeRequirement.swift; sourceTree = "<group>"; };
@@ -2505,6 +2507,7 @@
 				558328562B97A83A000CEC89 /* Encoders */,
 				558CF1A72B8680E100AF5D82 /* Formatters */,
 				555FB1672B73FB6300EE14BD /* Entities */,
+				D00E717D4815E62212E26C75 /* Resolvers */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -3327,6 +3330,15 @@
 			path = ProcessorExtensions;
 			sourceTree = "<group>";
 		};
+		D00E717D4815E62212E26C75 /* Resolvers */ = {
+			isa = PBXGroup;
+			children = (
+				579AB305E7D8B83237CB22B1 /* OpenID4VCIPreAuthTokenResolverTests.swift */,
+			);
+			name = Resolvers;
+			path = Resolvers;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -4060,6 +4072,7 @@
 				55A268A82CC1B70300A8EA9C /* JwsHeaderFormatterTests.swift in Sources */,
 				559BD4F5299EEC9500BD61AC /* MockVerifiedIdRequester.swift in Sources */,
 				55DECC3F29BFEACB00D5C802 /* MockVerifiableCredentialHelper.swift in Sources */,
+				C2664A8238035CC7F3F12290 /* OpenID4VCIPreAuthTokenResolverTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WalletLibrary/WalletLibrary/Networking/Entities/OpenID4VCI/CredentialMetadata.swift
+++ b/WalletLibrary/WalletLibrary/Networking/Entities/OpenID4VCI/CredentialMetadata.swift
@@ -53,12 +53,15 @@ extension CredentialMetadata
         let authorizationServers = try Self.getRequiredProperty(property: authorization_servers,
                                                                 propertyName: "authorization_servers")
         
-        let authorizatinServerURLHosts = authorizationServers.compactMap { URL(string: $0)?.host }
+        // Compare on the full normalized origin (scheme + host + port + path), not just the host.
+        // A host-only comparison lets an attacker substitute an authorization server that shares the
+        // host but differs in scheme/port/path, defeating the binding the offer is meant to enforce.
+        let metadataAuthServerIdentifiers = authorizationServers.compactMap { URL(string: $0)?.normalizedIdentifier }
         
         for grant in credentialOffer.grants
         {
-            guard let authServerURLHostFromGrant = URL(string: grant.value.authorization_server)?.host,
-                  authorizatinServerURLHosts.contains(authServerURLHostFromGrant) else
+            guard let grantAuthServerIdentifier = URL(string: grant.value.authorization_server)?.normalizedIdentifier,
+                  metadataAuthServerIdentifiers.contains(grantAuthServerIdentifier) else
             {
                 let errorMessage = "Authorization servers in Credential Metadata does not contain \(grant.value.authorization_server)"
                 throw OpenId4VCIValidationError.MalformedCredentialMetadata(message: errorMessage)
@@ -152,5 +155,64 @@ extension SignedMetadata
         
         try validateIatIfPresent()
         try validateExpIfPresent()
+    }
+    
+    /// Ensures the signed metadata token carries an expiry (`exp`) claim.
+    /// A token without an expiry never expires and can be replayed indefinitely, so a missing
+    /// `exp` is treated as a malformed token rather than silently accepted.
+    func validateExpiryIsPresent() throws
+    {
+        if content.exp == nil
+        {
+            throw TokenValidationError.InvalidProperty("exp", actual: nil, expected: "a non-nil expiry claim")
+        }
+    }
+}
+
+/**
+ * Helpers for comparing URLs by a normalized origin identity rather than by raw string or host alone.
+ */
+extension URL
+{
+    /// A normalized, comparable identifier for this URL: lowercased scheme and host, an explicit
+    /// port (defaulting https=443 / http=80), and a path with trailing slashes trimmed.
+    /// Returns nil when the scheme or host is missing (e.g. a bare, non-URL string).
+    var normalizedIdentifier: String?
+    {
+        guard let scheme = scheme?.lowercased(),
+              let host = host?.lowercased() else
+        {
+            return nil
+        }
+        
+        let defaultPort: Int
+        switch scheme
+        {
+            case "https": defaultPort = 443
+            case "http": defaultPort = 80
+            default: defaultPort = -1
+        }
+        let resolvedPort = port ?? defaultPort
+        
+        var normalizedPath = path
+        while normalizedPath.hasSuffix("/")
+        {
+            normalizedPath = String(normalizedPath.dropLast())
+        }
+        
+        return "\(scheme)://\(host):\(resolvedPort)\(normalizedPath)"
+    }
+    
+    /// Returns true only when both strings parse to URLs that share the same normalized identifier.
+    /// A non-URL string (no scheme/host) never matches, which intentionally rejects loosely formed values.
+    static func haveSameIdentifier(_ lhs: String, _ rhs: String) -> Bool
+    {
+        guard let lhsIdentifier = URL(string: lhs)?.normalizedIdentifier,
+              let rhsIdentifier = URL(string: rhs)?.normalizedIdentifier else
+        {
+            return false
+        }
+        
+        return lhsIdentifier == rhsIdentifier
     }
 }

--- a/WalletLibrary/WalletLibrary/Networking/Resolvers/OpenID4VCIPreAuthTokenResolver.swift
+++ b/WalletLibrary/WalletLibrary/Networking/Resolvers/OpenID4VCIPreAuthTokenResolver.swift
@@ -64,6 +64,15 @@ struct OpenID4VCIPreAuthTokenResolver
             throw OpenId4VCIValidationError.PreAuthError(message: "Missing token endpoint in well-known configuration.")
         }
         
+        // RFC 8414 §3.3: the `issuer` returned in the authorization server metadata MUST be identical
+        // to the authorization server identifier used to fetch it. Enforcing this prevents a malicious
+        // host from serving metadata that impersonates a legitimate authorization server.
+        guard let wellKnownIssuer = wellKnownConfiguration.issuer,
+              URL.haveSameIdentifier(wellKnownIssuer, authorizationServer) else
+        {
+            throw OpenId4VCIValidationError.PreAuthError(message: "Well-known configuration issuer does not match the requested authorization server.")
+        }
+        
         return tokenEndpointURL
     }
 }

--- a/WalletLibrary/WalletLibrary/Requests/Processors/OpenId4VCIProcessor.swift
+++ b/WalletLibrary/WalletLibrary/Requests/Processors/OpenId4VCIProcessor.swift
@@ -57,6 +57,18 @@ struct OpenId4VCIProcessor: RequestProcessing
         let credentialOffer = try configuration.mapper.map(requestJson, type: CredentialOffer.self)
         let credentialMetadata = try await fetchCredentialMetadata(url: credentialOffer.credential_issuer)
         
+        /// Bind the fetched metadata to the offer's `credential_issuer`.
+        /// The metadata is fetched from the offer's issuer, but the issuer it advertises must also match.
+        /// Without this check a spoofed issuer can return metadata that points the wallet at a victim
+        /// authorization server / credential endpoint, enabling PIN harvesting and issuer impersonation.
+        let metadataCredentialIssuer = try CredentialMetadata.getRequiredProperty(property: credentialMetadata.credential_issuer,
+                                                                                  propertyName: "credential_issuer")
+        guard URL.haveSameIdentifier(credentialOffer.credential_issuer, metadataCredentialIssuer) else
+        {
+            let errorMessage = "Credential metadata issuer does not match the credential offer issuer."
+            throw OpenId4VCIValidationError.MalformedCredentialMetadata(message: errorMessage)
+        }
+        
         /// Validate the `CredentialMetadata` contains credential config ids from `CredentialOffer`.
         let configIds = credentialOffer.credential_configuration_ids
         guard let credentialConfig = credentialMetadata.getCredentialConfigurations(ids: configIds).first else

--- a/WalletLibrary/WalletLibrary/Requests/Processors/SignedCredentialMetadataProcessor.swift
+++ b/WalletLibrary/WalletLibrary/Requests/Processors/SignedCredentialMetadataProcessor.swift
@@ -60,6 +60,8 @@ struct SignedCredentialMetadataProcessor: SignedCredentialMetadataProcessing
         // Validate signature and claims in token and wrap error in `OpenId4VCIValidationError` if thrown.
         do
         {
+            try signedMetadataToken.validateExpiryIsPresent()
+            
             try signedMetadataToken.validateClaims(expectedSubject: credentialIssuer,
                                                    expectedIssuer: kid.did)
             

--- a/WalletLibrary/WalletLibraryTests/Mocks/Requests/Manifest/MockIssuanceResponseContaining.swift
+++ b/WalletLibrary/WalletLibraryTests/Mocks/Requests/Manifest/MockIssuanceResponseContaining.swift
@@ -7,9 +7,13 @@
 
 struct MockIssuanceResponseContainer: IssuanceResponseContaining {
     
+    let audienceUrl: String
+    
     private let mockAddRequirementCallback: ((Requirement) throws -> Void)?
     
-    init(mockAddRequirementCallback: ((Requirement) throws -> Void)? = nil) {
+    init(audienceUrl: String = "",
+         mockAddRequirementCallback: ((Requirement) throws -> Void)? = nil) {
+        self.audienceUrl = audienceUrl
         self.mockAddRequirementCallback = mockAddRequirementCallback
     }
     

--- a/WalletLibrary/WalletLibraryTests/Networking/Resolvers/OpenID4VCIPreAuthTokenResolverTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Networking/Resolvers/OpenID4VCIPreAuthTokenResolverTests.swift
@@ -57,7 +57,7 @@ class OpenID4VCIPreAuthTokenResolverTests: XCTestCase
         let mockAccessToken = "mock access token"
         let expectedResponse = PreAuthTokenResponse(access_token: mockAccessToken,
                                                     token_type: nil,
-                                                    expires_in: nil)
+                                                    time_to_live_in_seconds: nil)
         let oidcConfigResponse = OpenIDWellKnownConfiguration(issuer: "",
                                                               token_endpoint: "",
                                                               grant_types_supported: ["invalidGrantType"])
@@ -94,7 +94,7 @@ class OpenID4VCIPreAuthTokenResolverTests: XCTestCase
         let expectedGrantType = "urn:ietf:params:oauth:grant-type:pre-authorized_code"
         let expectedResponse = PreAuthTokenResponse(access_token: mockAccessToken,
                                                     token_type: nil,
-                                                    expires_in: nil)
+                                                    time_to_live_in_seconds: nil)
         let oidcConfigResponse = OpenIDWellKnownConfiguration(issuer: "",
                                                               token_endpoint: nil,
                                                               grant_types_supported: [expectedGrantType])
@@ -130,7 +130,7 @@ class OpenID4VCIPreAuthTokenResolverTests: XCTestCase
         let expectedGrantType = "urn:ietf:params:oauth:grant-type:pre-authorized_code"
         let expectedResponse = PreAuthTokenResponse(access_token: nil,
                                                     token_type: nil,
-                                                    expires_in: nil)
+                                                    time_to_live_in_seconds: nil)
         let oidcConfigResponse = OpenIDWellKnownConfiguration(issuer: "https://microsoft.com",
                                                               token_endpoint: "https://microsoft.com",
                                                               grant_types_supported: [expectedGrantType])
@@ -166,7 +166,7 @@ class OpenID4VCIPreAuthTokenResolverTests: XCTestCase
         let expectedGrantType = "urn:ietf:params:oauth:grant-type:pre-authorized_code"
         let expectedResponse = PreAuthTokenResponse(access_token: mockAccessToken,
                                                     token_type: nil,
-                                                    expires_in: nil)
+                                                    time_to_live_in_seconds: nil)
         let oidcConfigResponse = OpenIDWellKnownConfiguration(issuer: "https://microsoft.com",
                                                               token_endpoint: "https://microsoft.com",
                                                               grant_types_supported: [expectedGrantType])
@@ -196,7 +196,7 @@ class OpenID4VCIPreAuthTokenResolverTests: XCTestCase
         let expectedGrantType = "urn:ietf:params:oauth:grant-type:pre-authorized_code"
         let expectedResponse = PreAuthTokenResponse(access_token: mockAccessToken,
                                                     token_type: nil,
-                                                    expires_in: nil)
+                                                    time_to_live_in_seconds: nil)
         let oidcConfigResponse = OpenIDWellKnownConfiguration(issuer: "https://malicious.example.com",
                                                               token_endpoint: "https://microsoft.com",
                                                               grant_types_supported: [expectedGrantType])

--- a/WalletLibrary/WalletLibraryTests/Networking/Resolvers/OpenID4VCIPreAuthTokenResolverTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Networking/Resolvers/OpenID4VCIPreAuthTokenResolverTests.swift
@@ -131,7 +131,7 @@ class OpenID4VCIPreAuthTokenResolverTests: XCTestCase
         let expectedResponse = PreAuthTokenResponse(access_token: nil,
                                                     token_type: nil,
                                                     expires_in: nil)
-        let oidcConfigResponse = OpenIDWellKnownConfiguration(issuer: "",
+        let oidcConfigResponse = OpenIDWellKnownConfiguration(issuer: "https://microsoft.com",
                                                               token_endpoint: "https://microsoft.com",
                                                               grant_types_supported: [expectedGrantType])
         let expectedResults: [(any Decodable, any InternalNetworkOperation.Type)] =
@@ -167,7 +167,7 @@ class OpenID4VCIPreAuthTokenResolverTests: XCTestCase
         let expectedResponse = PreAuthTokenResponse(access_token: mockAccessToken,
                                                     token_type: nil,
                                                     expires_in: nil)
-        let oidcConfigResponse = OpenIDWellKnownConfiguration(issuer: "",
+        let oidcConfigResponse = OpenIDWellKnownConfiguration(issuer: "https://microsoft.com",
                                                               token_endpoint: "https://microsoft.com",
                                                               grant_types_supported: [expectedGrantType])
         let expectedResults: [(any Decodable, any InternalNetworkOperation.Type)] =
@@ -187,5 +187,42 @@ class OpenID4VCIPreAuthTokenResolverTests: XCTestCase
         // Assert
         XCTAssertEqual(result, mockAccessToken)
         
+    }
+    
+    func testResolve_WithMismatchedIssuer_ThrowsError() async throws
+    {
+        // Arrange
+        let mockAccessToken = "mock access token"
+        let expectedGrantType = "urn:ietf:params:oauth:grant-type:pre-authorized_code"
+        let expectedResponse = PreAuthTokenResponse(access_token: mockAccessToken,
+                                                    token_type: nil,
+                                                    expires_in: nil)
+        let oidcConfigResponse = OpenIDWellKnownConfiguration(issuer: "https://malicious.example.com",
+                                                              token_endpoint: "https://microsoft.com",
+                                                              grant_types_supported: [expectedGrantType])
+        let expectedResults: [(any Decodable, any InternalNetworkOperation.Type)] =
+        [
+            (expectedResponse, OpenID4VCIPreAuthTokenPostOperation.self),
+            (oidcConfigResponse, OpenIDWellKnownConfigFetchOperation.self)
+        ]
+        let mockNetworking = MockLibraryNetworking.create(expectedResults: expectedResults)
+        let configuration = LibraryConfiguration(networking: mockNetworking)
+        let resolver = OpenID4VCIPreAuthTokenResolver(configuration: configuration)
+        let grant = CredentialOfferGrant(authorization_server: "https://microsoft.com",
+                                         pre_authorized_code: "mockCode")
+        
+        // Act / Assert
+        do
+        {
+            let _ = try await resolver.resolve(using: grant)
+            XCTFail()
+        }
+        catch
+        {
+            XCTAssert(error is OpenId4VCIValidationError)
+            let validationError = error as! OpenId4VCIValidationError
+            XCTAssertEqual(validationError.message, "Well-known configuration issuer does not match the requested authorization server.")
+            XCTAssertEqual(validationError.code, "preauth_issuance_error")
+        }
     }
 }

--- a/WalletLibrary/WalletLibraryTests/Requests/Processors/OpenId4VCIProcessorTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Requests/Processors/OpenId4VCIProcessorTests.swift
@@ -134,6 +134,58 @@ class OpenId4VCIProcessorTests: XCTestCase
         }
     }
     
+    func testProcess_WithMismatchedIssuerInMetadata_ThrowsError() async throws
+    {
+        // Arrange
+        let rawRequest = createJSONCredentialOffer()
+        let metadata = createCredentialMetadata(credentialIssuer: "https://evil.example.com")
+        let expectedResult = (metadata, CredentialMetadataFetchOperation.self)
+        let mockNetworking = MockLibraryNetworking.create(expectedResults: [expectedResult])
+        let configuration = LibraryConfiguration(networking: mockNetworking)
+        let handler = OpenId4VCIProcessor(configuration: configuration)
+        
+        do
+        {
+            // Act
+            let _ = try await handler.process(rawRequest: rawRequest)
+            XCTFail()
+        }
+        catch
+        {
+            // Assert
+            XCTAssert(error is OpenId4VCIValidationError)
+            let validationError = error as! OpenId4VCIValidationError
+            XCTAssertEqual(validationError.code, "credential_metadata_malformed")
+            XCTAssertEqual(validationError.message, "Credential metadata issuer does not match the credential offer issuer.")
+        }
+    }
+    
+    func testProcess_WithSchemeMismatchedAuthServer_ThrowsError() async throws
+    {
+        // Arrange
+        let rawRequest = createJSONCredentialOffer()
+        let metadata = createCredentialMetadata(authorizationServer: "http://login.microsoft.com")
+        let expectedResult = (metadata, CredentialMetadataFetchOperation.self)
+        let mockNetworking = MockLibraryNetworking.create(expectedResults: [expectedResult])
+        let configuration = LibraryConfiguration(networking: mockNetworking)
+        let handler = OpenId4VCIProcessor(configuration: configuration)
+        
+        do
+        {
+            // Act
+            let _ = try await handler.process(rawRequest: rawRequest)
+            XCTFail()
+        }
+        catch
+        {
+            // Assert
+            XCTAssert(error is OpenId4VCIValidationError)
+            let validationError = error as! OpenId4VCIValidationError
+            XCTAssertEqual(validationError.code, "credential_metadata_malformed")
+            XCTAssertEqual(validationError.message, "Authorization servers in Credential Metadata does not contain https://login.microsoft.com")
+        }
+    }
+    
     func testProcess_WithSignedMetadataProcessorError_ThrowsError() async throws
     {
         // Arrange
@@ -222,6 +274,7 @@ class OpenId4VCIProcessorTests: XCTestCase
     
     private func createCredentialMetadata(expectedConfigIds: [String] = ["expectedCredentialId"],
                                           authorizationServer: String = "https://login.microsoft.com",
+                                          credentialIssuer: String = "https://issuer.example.com",
                                           scope: String? = "expectedScope") -> CredentialMetadata
     {
         let credentialConfigs: [String: CredentialConfiguration] = expectedConfigIds.reduce(into: [:]) { (result, id) in
@@ -235,7 +288,7 @@ class OpenId4VCIProcessorTests: XCTestCase
             return result[id] = credentialConfig
         }
 
-        let metadata = CredentialMetadata(credential_issuer: "credentialIssuer",
+        let metadata = CredentialMetadata(credential_issuer: credentialIssuer,
                                           authorization_servers: [authorizationServer],
                                           credential_endpoint: nil,
                                           notification_endpoint: nil,
@@ -248,7 +301,7 @@ class OpenId4VCIProcessorTests: XCTestCase
     private func createJSONCredentialOffer() -> [String: Any]
     {
         let json: [String: Any] = [
-            "credential_issuer": "expectedCredentialIssuer",
+            "credential_issuer": "https://issuer.example.com",
             "issuer_session": "expectedIssuerSession",
             "credential_configuration_ids": ["expectedCredentialId"],
             "grants": [

--- a/WalletLibrary/WalletLibraryTests/Requests/Processors/SignedCredentialMetadataProcessorTests.swift
+++ b/WalletLibrary/WalletLibraryTests/Requests/Processors/SignedCredentialMetadataProcessorTests.swift
@@ -166,6 +166,47 @@ class SignedCredentialMetadataProcessorTests: XCTestCase
         }
     }
     
+    func testProcess_WithMissingExpClaim_ThrowsError() async throws
+    {
+        // Arrange
+        let keyId = "#mockKeyId"
+        let did = "did:test:mock"
+        let credentialIssuer = "credentialIssuer"
+        let mockDocumentResolver = MockIdentifierDocumentResolver(mockResolve: createMockResolve(keyId))
+        let mockRootOfTrustResolver = MockRootOfTrustResolver()
+        let mockTokenVerifier = MockTokenVerifier(isTokenValid: true)
+        let processor = SignedCredentialMetadataProcessor(tokenVerifier: mockTokenVerifier,
+                                                          identifierDocumentResolver:mockDocumentResolver,
+                                                          rootOfTrustResolver: mockRootOfTrustResolver)
+        
+        // `exp` is intentionally omitted (nil) to exercise the missing-expiry guard.
+        let metadataTokenClaims = SignedMetadataTokenClaims(sub: credentialIssuer,
+                                                            iss: did)
+        
+        let signedMetadata = SignedMetadata(headers: Header(keyId: "\(did)\(keyId)"),
+                                                     content: metadataTokenClaims)!
+        let serializedMetadata = try signedMetadata.serialize()
+        
+        do
+        {
+            // Act
+            let _ = try await processor.process(signedMetadata: serializedMetadata,
+                                                credentialIssuer: credentialIssuer)
+            XCTFail()
+        }
+        catch
+        {
+            // Assert
+            XCTAssert(error is OpenId4VCIValidationError)
+            let validationError = error as! OpenId4VCIValidationError
+            XCTAssertEqual(validationError.code, "signed_metadata_token_malformed")
+            XCTAssertEqual(validationError.message, "Signed metadata is not valid.")
+            XCTAssert(validationError.error is TokenValidationError)
+            let tokenError = validationError.error as! TokenValidationError
+            XCTAssertEqual(tokenError.code, "invalid_property")
+        }
+    }
+    
     func testProcess_WithSignatureFailed_ThrowsError() async throws
     {
         // Arrange


### PR DESCRIPTION
## Summary

Hardens the wallet's **client-side trust-validation layer** for OpenID4VCI pre-authorized-code issuance. Today a spoofed/look-alike issuer can substitute its own credential metadata and authorization server, causing the wallet to send the user's **PIN / `tx_code`** to an attacker-controlled token endpoint and to **trust an impersonated issuer**. These are confirmed Tier-1 findings.

- ICM: `31000000635400` (PIN/`tx_code` harvesting via issuer spoofing — CWE-346/290), `31000000635152` (issuer impersonation / `signed_metadata` replay — CWE-346/294/345)
- PBI: `3675591`

## Where the change sits (trust-validation sequence)

All four fixes harden checks the wallet **already performs in sequence** during pre-auth issuance — no new round trips, no new dependencies.

```mermaid
sequenceDiagram
    autonumber
    participant W as Wallet (SDK)
    participant I as Credential Issuer
    participant AS as Authorization Server

    W->>W: Parse Credential Offer<br/>(credential_issuer, authorization_server, tx_code/PIN)
    W->>I: GET credential metadata
    I-->>W: Credential metadata (+ signed_metadata JWT)
    rect rgb(235,245,255)
    note over W: TRUST-VALIDATION LAYER (this PR)
    W->>W: Fix 1 — offer.credential_issuer == metadata.credential_issuer
    W->>W: Fix 2 — signed_metadata JWT MUST carry exp
    W->>W: Fix 4 — authorization_server matched by full origin (scheme+host+port)
    end
    W->>AS: GET /.well-known (RFC 8414)
    AS-->>W: Well-known config (issuer, token_endpoint)
    rect rgb(235,245,255)
    W->>W: Fix 5 — well-known.issuer == requested authorization_server
    end
    W->>AS: POST pre-authorized_code + tx_code/PIN
    AS-->>W: Access token
```

## Fixes (all on-by-default)

| # | Layer | Change | Blocks |
|---|-------|--------|--------|
| **1** | `OpenId4VCIProcessor` | Bind credential-offer issuer to fetched metadata `credential_issuer` after fetch | Metadata / issuer substitution |
| **2** | `SignedCredentialMetadataProcessor` + `SignedMetadata.validateExpiryIsPresent()` | Require `exp` claim on the `signed_metadata` JWT | Indefinite `signed_metadata` replay |
| **4** | `CredentialMetadata.validateAuthorizationServers` + `URL` origin helpers | Compare `authorization_server` by **full origin** (scheme+host+port), not host-only | Scheme/port downgrade to attacker AS |
| **5** | `OpenID4VCIPreAuthTokenResolver` | Enforce RFC 8414 `issuer` == requested `authorization_server` | Token-endpoint redirection |

Negative unit tests added for each fix.

## Scope decisions

- **Deferred — Fix 6 (VC JWT signature verification):** requires threading a verifier into `OpenID4VCIVerifiedId.init`; larger surface, tracked separately under the PBI.
- **Excluded — Fix 3 (strict same-origin issuer↔AS):** would break legitimate Entra deployments where the AS is a different origin than the issuer.

## Impact & rollout

- **Behavioral:** may reject **loosely-conformant issuers** (missing `signed_metadata.exp`, scheme/port-mismatched AS, or a `.well-known` `issuer` that doesn't match the offer's AS). All are spec-required, but real-world issuers may be lax.
- **No opt-in flag** — these are correctness/security invariants; gating them behind a disabled-by-default flag would leave shipped wallets vulnerable. The existing `OpenID4VCIPreAuth`/`OpenID4VCIAccessToken` preview flags only gate a `Prefer` header, **not** this validation path.
- Recommend **telemetry-first** rollout: watch new rejection error codes (`credential_metadata_malformed`, `signed_metadata_token_malformed`, `preauth_issuance_error`) before broad release.

## Testing

Verified locally via `xcodebuild test` (Xcode 26.5, iPhone 17 simulator, `WalletLibrary+VCSDK` scheme). **All four new security tests pass:**

| Fix | Test |
|----|------|
| **1** | `OpenId4VCIProcessorTests.testProcess_WithMismatchedIssuerInMetadata_ThrowsError` |
| **2** | `SignedCredentialMetadataProcessorTests.testProcess_WithMissingExpClaim_ThrowsError` (+ `JwsTokenExtensionTests.testValidateExp_WithMissingExp_DoesThrows`) |
| **4** | `OpenId4VCIProcessorTests.testProcess_WithSchemeMismatchedAuthServer_ThrowsError` |
| **5** | `OpenID4VCIPreAuthTokenResolverTests.testResolve_WithMismatchedIssuer_ThrowsError` |

Existing happy-path fixtures were realigned to real URLs so the new origin/issuer checks pass.

### Test-build unblocks (required for the suite to compile/run)

Two pre-existing issues had to be fixed for the test target to build and for Fix 5's suite to execute at all:

- **`project.pbxproj`** — `OpenID4VCIPreAuthTokenResolverTests.swift` existed in the repo but had never been added to the `WalletLibraryTests` Xcode target, so its 7 tests (incl. the Fix 5 test) were **silently skipped**. Wired the file into the target. Also corrected `PreAuthTokenResponse` initializer label drift (`expires_in:` → `time_to_live_in_seconds:`) at 5 call sites, since the never-compiled file had diverged from the current struct API.
- **`MockIssuanceResponseContaining.swift`** — added `audienceUrl` to satisfy the `IssuanceResponseContaining` protocol (pre-existing break from #145); without it the whole test target fails to compile.

### Pre-existing failures (not introduced by this PR)

Three failures remain, all in files this PR does **not** touch and unreachable by the validation-only code here:
- `VerifiedIdEncoderTests.testDecode_WithValidVerifiedId_ReturnsData` and `OpenID4VCIVerifiedIDTests.testEncode_WithValidInputs_EncodesVCProperly` — nondeterministic `Data`/JSON key-ordering flakes (`JSONEncoder()` without `.sortedKeys`); the encoder test **passes on isolated re-run**.
- `OpenIdPresentationRequestTests.testComplete_WithSerializationAndSucceeds_ReturnsVoid` — presentation-flow mock-infra limitation (`MockingNotSupportedForOperation`).

---
🤖 Generated with assistance from Copilot. Co-authored-by: Copilot.
